### PR TITLE
Add tests/ directory, and cherry-pick latest changes from downstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,23 @@ lint: develop ## Runs flake8, pylint and yamllint
 fmt: requirements-dev ## Formats python files with black
 	$(BIN)/black --config=$(LINTERS)/black --experimental-string-processing $(PY_SRCS)
 
-# TODO: Uncomment once tests are added here
-# test: clean develop ## Cleans cache and runs test suite using Pytest
-# 	$(BIN)/pytest -v tests
+test: clean develop ## Cleans cache and runs test suite using Pytest
+	$(BIN)/pytest --cache-clear -v tests
+
+##@ Build & Deploy
+
+ENVIRONMENTS := stage integration production
+check: develop ## Runs the style check, the code check and all the tasks in dry-run mode
+	for task_type in check deploy; do \
+		for env in $(ENVIRONMENTS); do \
+			$(BIN)/managedtenants --environment=$${env} run --dry-run tasks/$${task_type}/ ; \
+		done \
+	done
+
+build-deploy: develop ## Runs the 'deploy' tasks in debug mode
+	for env in $(ENVIRONMENTS); do \
+		$(BIN)/managedtenants --environment=$${env} run --debug tasks/deploy/ ; \
+	done
 
 ##@ Generators
 

--- a/docs/tenants/zz_schema_generated.md
+++ b/docs/tenants/zz_schema_generated.md
@@ -50,6 +50,14 @@
 
   - **Items** *(string)*
 
+- **`commonLabels`** *(object)*
+
+  - **Items** *(string)*
+
+- **`commonAnnotations`** *(object)*
+
+  - **Items** *(string)*
+
 - **`defaultChannel`** *(string)*: Must be one of: `['alpha', 'beta', 'stable', 'edge', 'rc']`.
 
 - **`ocmQuotaName`** *(string)*

--- a/managedtenants/data/macros.j2
+++ b/managedtenants/data/macros.j2
@@ -1,0 +1,20 @@
+# vi: ft=jinja :
+{% macro expand_dict(d) %}
+  {% for k,v in d.items() %}
+'{{ k }}': '{{ v }}'
+  {% endfor %}
+{% endmacro %}
+
+{% macro maybe_labels(labels) %}
+{% if labels %}
+labels:
+{{ expand_dict(labels) | indent(2, first=True) }}
+{%- endif %}
+{% endmacro %}
+
+{% macro maybe_annotations(annotations) %}
+{% if annotations %}
+annotations:
+{{ expand_dict(annotations) | indent(2, first=True) }}
+{%- endif %}
+{% endmacro %}

--- a/managedtenants/data/metadata.schema.yaml
+++ b/managedtenants/data/metadata.schema.yaml
@@ -70,6 +70,16 @@ properties:
     items:
       type: string
       pattern: ^[A-Za-z0-9-_.]+$
+  commonLabels:
+    type: object
+    items:
+      type: string
+      pattern: ^[A-Za-z0-9-_.]+$
+  commonAnnotations:
+    type: object
+    items:
+      type: string
+      pattern: ^[A-Za-z0-9-_.]+$
   defaultChannel:
     type: string
     enum:

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -1,7 +1,11 @@
+{# vi: ft=jinja : #}
+{% from 'macros.j2' import maybe_labels, maybe_annotations %}
+---
 kind: List
 metadata: {}
 apiVersion: v1
 items:
+{# addon v1 create OLM resources manually #}
 {% if ADDON.manager == AddonManager.UKNOWN %}
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -18,15 +22,17 @@ items:
     - apiVersion: v1
       kind: Namespace
       metadata:
-        annotations:
-          openshift.io/node-selector: ''
-          {% for key, value in ADDON.metadata['namespaceAnnotations'].items() %}{{key}}: '{{value}}'
-          {% endfor %}
-        {% if ADDON.metadata['namespaceLabels'] %}
-        labels:
-          {% for key, value in ADDON.metadata['namespaceLabels'].items() %}{{key}}: '{{value}}'
-          {% endfor %}
-        {% endif %}
+        {{
+            maybe_annotations(ADDON.metadata.get('namespaceAnnotations', {})
+              | merge_dicts(ADDON.metadata.get('commonAnnotations', {}))
+              | merge_dicts({'openshift.io/node-selector': ''}))
+              | indent(8)
+        }}
+        {{
+            maybe_labels(ADDON.metadata['namespaceLabels']
+              | merge_dicts(ADDON.metadata.get('commonLabels', {})))
+              | indent(8)
+        }}
         name: {{namespace}}
 
     {% if ADDON.metadata['pullSecret'] is defined %}
@@ -35,20 +41,26 @@ items:
       metadata:
         name: addon-{{ADDON.metadata['id']}}-pullsecret
         namespace: {{namespace}}
-      labels:
-        addon-pullsecret: "{{ADDON.metadata['id']}}"
+        {{ maybe_annotations(ADDON.metadata.get('commonAnnotations')) | indent(8) }}
+        {{
+            maybe_labels(ADDON.metadata.get('commonLabels', {})
+              | merge_dicts({'addon-pullsecret': ADDON.metadata['id']}))
+              | indent(8)
+        }}
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: >-
           {{ADDON.metadata['pullSecret']}}
     {% endif %}
-
 {% endfor %}
+
     - apiVersion: operators.coreos.com/v1alpha1
       kind: CatalogSource
       metadata:
         name: addon-{{ADDON.metadata['id']}}-catalog
         namespace: openshift-marketplace
+        {{ maybe_annotations(ADDON.metadata.get('commonAnnotations')) | indent(8) }}
+        {{ maybe_labels(ADDON.metadata.get('commonLabels')) | indent(8) }}
       spec:
         displayName: {{ADDON.metadata['name']}}
         image: {{ADDON.image_tag.format(hash='${IMAGE_TAG}')}}
@@ -61,6 +73,8 @@ items:
       metadata:
         name: redhat-layered-product-og
         namespace: {{ADDON.metadata['targetNamespace']}}
+        {{ maybe_annotations(ADDON.metadata.get('commonAnnotations')) | indent(8) }}
+        {{ maybe_labels(ADDON.metadata.get('commonLabels')) | indent(8) }}
       {% if ADDON.metadata['installMode'] in ['SingleNamespace', 'OwnNamespace'] %}
       spec:
         targetNamespaces:
@@ -73,6 +87,8 @@ items:
       metadata:
         name: addon-{{ADDON.metadata['id']}}
         namespace: {{ADDON.metadata['targetNamespace']}}
+        {{ maybe_annotations(ADDON.metadata.get('commonAnnotations')) | indent(8) }}
+        {{ maybe_labels(ADDON.metadata.get('commonLabels')) | indent(8) }}
       spec:
         channel: {{ADDON.metadata['defaultChannel']}}
         name: {{ADDON.metadata['id']}}
@@ -84,11 +100,8 @@ items:
 {% if ADDON.metadata['startingCSV'] is defined %}
         startingCSV: {{ADDON.metadata['startingCSV']}}
 {% endif %}
-{% if ADDON.metadata['extraResources'] is defined %}
-  {% for resource in ADDON.metadata['extraResources'] %}
-- {% filter indent(width=2) %}{% include resource %}{% endfilter %}
-  {% endfor %}
-{% endif %}
+
+{# addon v2 create the Addon CR #}
 {% elif ADDON.manager == AddonManager.ADDON_OPERATOR %}
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -135,13 +148,14 @@ items:
           {{ADDON.metadata['pullSecret']}}
     {% endif %}
 {% endfor %}
+{% endif %}
 
 {% if ADDON.metadata['extraResources'] is defined %}
   {% for resource in ADDON.metadata['extraResources'] %}
 - {% filter indent(width=2) %}{% include resource %}{% endfilter %}
   {% endfor %}
 {% endif %}
-{% endif %}
+
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -1,7 +1,8 @@
+import re
 from datetime import datetime, timedelta
 
-import re
 import requests
+from sretoolbox.utils import retry
 
 
 class OcmCli:
@@ -172,6 +173,7 @@ class OcmCli:
     def _post(self, path, **kwargs):
         return self._api(requests.post, path, **kwargs)
 
+    @retry()
     def _get(self, path, **kwargs):
         return self._api(requests.get, path, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -14,50 +14,49 @@
 
 import os
 
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 BASE_PATH = os.path.dirname(__file__)
 
 
 def get_readme_content():
-    with open(os.path.join(BASE_PATH, 'README.md'), 'r') as readme:
+    with open(os.path.join(BASE_PATH, "README.md"), "r") as readme:
         return readme.read()
 
 
 def get_version():
-    with open(os.path.join(BASE_PATH, 'VERSION'), 'r') as version:
+    with open(os.path.join(BASE_PATH, "VERSION"), "r") as version:
         return version.read().strip()
 
 
-setup(name='managedtenants_cli',
-      packages=find_packages(),
-      version=get_version(),
-      author='Red Hat Managed Tenants SRE Team',
-      author_email="sd-mt-sre@redhat.com",
-      url='https://github.com/mt-sre/managed-tenants-cli',
-      description='Set of libraries commonly across MT-SRE projects',
-      long_description=get_readme_content(),
-      python_requires='>=3.6',
-      license="Apache-2.0",
-      classifiers=
-      [
-            'Intended Audience :: Developers',
-            'License :: OSI Approved :: Apache Software License',
-            'Natural Language :: English',
-            'Operating System :: POSIX :: Linux',
-            'Programming Language :: Python :: 3.6',
-            'Topic :: Software Development :: Libraries',
-      ],
-      install_requires=[
-            "Jinja2~=2.10",
-            "PyYAML~=5.1",
-            "jsonschema~=3.1",
-            "requests~=2.23",
-            "sretoolbox==0.10.0",
-            "semver~=2.9",
-            "python-gitlab~=2.6",
-            "checksumdir~=1.2",
-            "hypothesis~=6.17.4"
-      ]
+setup(
+    name="managedtenants_cli",
+    packages=find_packages(),
+    version=get_version(),
+    author="Red Hat Managed Tenants SRE Team",
+    author_email="sd-mt-sre@redhat.com",
+    url="https://github.com/mt-sre/managed-tenants-cli",
+    description="Set of libraries commonly across MT-SRE projects",
+    long_description=get_readme_content(),
+    python_requires=">=3.6",
+    license="Apache-2.0",
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Natural Language :: English",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Software Development :: Libraries",
+    ],
+    install_requires=[
+        "Jinja2~=2.10",
+        "PyYAML~=5.1",
+        "jsonschema~=3.1",
+        "requests~=2.23",
+        "sretoolbox==0.10.0",
+        "semver~=2.9",
+        "python-gitlab~=2.6",
+        "checksumdir~=1.2",
+        "hypothesis~=6.17.4",
+    ],
 )

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,27 @@
+# Test suite documentation
+
+## Description
+
+- The following tests are discovered and ran using `pytest`
+- Test files should be named `test_<something>.py`
+- It tries to mimic the directory structure of the `managedtenants/` package but this is not a hard requirement
+- Two special directories are:
+  - `testdata/` :: contains mock data to load an `Addon` from the filesystem
+  - `testutils/` :: python module to help running tests
+
+## `conftest.py`
+
+Pytest utilizes this file to configure itself. It currently sets some `hypothesis` profiles depending on where the test suite is executed (local machine, CI, nightly build, etc.).
+
+**Override default settings**
+
+It is always possible to [override any settings for a single test](https://hypothesis.readthedocs.io/en/latest/settings.html#settings):
+
+```python
+from hypothesis import given, settings
+
+@given(integers())
+@settings(max_examples=500)
+def test_this_thoroughly(x):
+    pass
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+# Configure different hypothesis profiles
+import os
+
+from hypothesis import HealthCheck, Phase, settings
+
+FAST_PROFILE = "fast"
+CI_PROFILE = "ci"
+
+
+# 'fast' profile for local development
+settings.register_profile(
+    FAST_PROFILE,
+    # Set to true for test reproducibility
+    # https://hypothesis.readthedocs.io/en/latest/settings.html#hypothesis.settings.derandomize
+    derandomize=False,
+    max_examples=3,
+    # https://hypothesis.readthedocs.io/en/latest/settings.html#controlling-what-runs
+    phases=[Phase.generate, Phase.explain],
+    # (sblaisdo) fails `HealthCheck.too_slow` with initial schema/addon loading
+    suppress_health_check=[HealthCheck.too_slow],
+    # (sblaisdo) default deadline of 200ms is exceeded in some cases
+    deadline=None,
+)
+
+# 'ci' profile for pr_check.sh
+settings.register_profile(
+    CI_PROFILE,
+    derandomize=False,
+    max_examples=5,
+    phases=[Phase.generate, Phase.explain],
+    suppress_health_check=[HealthCheck.too_slow],
+    deadline=None,
+)
+
+# Load profile
+p = CI_PROFILE if os.getenv("CI") == "true" else FAST_PROFILE
+print(f"Loading hypothesis profile: {p}")
+settings.load_profile(p)

--- a/tests/data/test_paths.py
+++ b/tests/data/test_paths.py
@@ -1,0 +1,13 @@
+import pytest
+from managedtenants.data.paths import DATA_DIR
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        {"dir": DATA_DIR, "expected": "data"},
+    ],
+)
+def test_directories(case):
+    assert case["dir"].is_dir()
+    assert case["dir"].stem == case["expected"]

--- a/tests/sss/test_labels_and_annotations.py
+++ b/tests/sss/test_labels_and_annotations.py
@@ -1,0 +1,73 @@
+import hypothesis.strategies as hypothesis_strategies
+import pytest
+import tests.testutils.strategies as custom_strategies
+from hypothesis import given
+from managedtenants.core.addons_loader.sss import Sss
+
+
+@given(data=hypothesis_strategies.data())
+@pytest.mark.parametrize(
+    "has_value",
+    [
+        True,
+        False,
+    ],
+)
+def test_common_labels_and_annotations(has_value, data):
+    env = data.draw(custom_strategies.environment())
+    addon = data.draw(custom_strategies.addon(env))
+
+    if has_value:
+        addon.metadata["commonLabels"] = data.draw(custom_strategies.labels())
+        addon.metadata["commonAnnotations"] = data.draw(
+            custom_strategies.labels()
+        )
+    else:
+        addon.metadata.pop("commonLabels", None)
+        addon.metadata.pop("commonAnnotations", None)
+
+    # Rerender selectorsyncset.yaml.j2
+    addon.sss = Sss(addon=addon)
+    walker = addon.sss.walker()
+
+    # Validate labels on CatalogSource
+    r = walker["sss_deploy"]["spec"]["resources"]["CatalogSource"][0][1]
+    if has_value:
+        for k, v in r["metadata"]["annotations"].items():
+            assert addon.metadata["commonAnnotations"][k] == v
+        for k, v in r["metadata"]["labels"].items():
+            assert addon.metadata["commonLabels"][k] == v
+    else:
+        # field should be undefined
+        for field in ["annotations", "labels"]:
+            with pytest.raises(KeyError):
+                _ = r["metadata"][field]
+
+
+@given(data=hypothesis_strategies.data())
+def test_namespace_labels_and_annotations_priority_over_common(data):
+    env = data.draw(custom_strategies.environment())
+    addon = data.draw(custom_strategies.addon(env))
+    duplicate_key, common_val, ns_val = data.draw(
+        hypothesis_strategies.lists(
+            custom_strategies.k8s_name(), min_size=3, max_size=3, unique=True
+        )
+    )
+    addon.metadata["namespaces"] = data.draw(
+        hypothesis_strategies.lists(
+            custom_strategies.namespace(), min_size=2, max_size=2, unique=True
+        )
+    )
+
+    addon.metadata["namespaceLabels"].update({duplicate_key: ns_val})
+    addon.metadata["namespaceAnnotations"].update({duplicate_key: ns_val})
+    addon.metadata["commonLabels"] = {duplicate_key: common_val}
+    addon.metadata["commonAnnotations"] = {duplicate_key: common_val}
+
+    # Rerender selectorsyncset.yaml.j2
+    addon.sss = Sss(addon=addon)
+    walker = addon.sss.walker()
+
+    for _, ns in walker["sss_deploy"]["spec"]["resources"]["Namespace"]:
+        assert ns["metadata"]["labels"][duplicate_key] == ns_val
+        assert ns["metadata"]["annotations"][duplicate_key] == ns_val

--- a/tests/sss/test_manual_install_plan.py
+++ b/tests/sss/test_manual_install_plan.py
@@ -1,0 +1,38 @@
+import hypothesis.strategies as hypothesis_strategies
+import pytest
+import tests.testutils.strategies as custom_strategies
+from hypothesis import given
+from managedtenants.core.addons_loader.sss import Sss
+
+
+@given(data=hypothesis_strategies.data())
+@pytest.mark.parametrize(
+    "case",
+    [
+        # An empty field is parsed as None by PyYAML
+        {"value": "undefined", "expected": None},
+        {"value": False, "expected": None},
+        {"value": True, "expected": "Manual"},
+    ],
+)
+def test_sss_manual_install_plan(case, data):
+    env = data.draw(custom_strategies.environment())
+    addon = data.draw(custom_strategies.addon(env))
+
+    if case["value"] == "undefined":
+        addon.metadata.pop("manualInstallPlanApproval", None)
+    else:
+        addon.metadata["manualInstallPlanApproval"] = case["value"]
+
+    # Rerender selectorsyncset.yaml.j2
+    addon.sss = Sss(addon=addon)
+    walker = addon.sss.walker()
+    subscription = walker["sss_deploy"]["spec"]["resources"]["Subscription"][0][
+        1
+    ]
+
+    if case["expected"] is None:
+        with pytest.raises(KeyError):
+            _ = subscription["spec"]["installPlanApproval"]
+    else:
+        assert subscription["spec"]["installPlanApproval"] == case["expected"]

--- a/tests/sss/test_sss_walker.py
+++ b/tests/sss/test_sss_walker.py
@@ -1,0 +1,75 @@
+import hypothesis.strategies as hypothesis_strategies
+import tests.testutils.strategies as custom_strategies
+from hypothesis import given
+from managedtenants.core.addons_loader.sss import Sss
+
+
+@given(hypothesis_strategies.data())
+def test_sss_deploy(data):
+    env = data.draw(custom_strategies.environment())
+    addon = data.draw(custom_strategies.addon(env))
+    # Set every field so that we render the template fully
+    addon.metadata["namespaces"] = data.draw(
+        hypothesis_strategies.lists(
+            custom_strategies.namespace(), min_size=2, max_size=5, unique=True
+        )
+    )
+    addon.metadata["pullSecret"] = data.draw(custom_strategies.k8s_name())
+    import json
+
+    print(json.dumps(addon.metadata, indent=4))
+
+    # Rerender template
+    addon.sss = Sss(addon=addon)
+    walker = addon.sss.walker()
+    resources = walker["sss_deploy"]["spec"]["resources"]
+
+    # Validate namespaces and secrets
+    assert len(resources["Namespace"]) == len(addon.metadata["namespaces"])
+    assert len(resources["Secret"]) == len(addon.metadata["namespaces"])
+    print(resources["Namespace"])
+    for ns, _ in resources["Namespace"]:
+        assert ns in addon.metadata["namespaces"]
+
+    # Validate CatalogSource, OperatorGroup, Subscription
+    for kind, name in [
+        (
+            "CatalogSource",
+            f"addon-{addon.metadata['id']}-catalog",
+        ),
+        (
+            "OperatorGroup",
+            "redhat-layered-product-og",
+        ),
+        (
+            "Subscription",
+            f"addon-{addon.metadata['id']}",
+        ),
+    ]:
+        assert len(resources[kind]) == 1
+        assert name == resources[kind][0][0]
+
+
+@given(hypothesis_strategies.data())
+def test_sss_delete(data):
+    env = data.draw(custom_strategies.environment())
+    addon = data.draw(custom_strategies.addon(env))
+    target_ns = data.draw(custom_strategies.namespace())
+    addon.metadata["targetNamespace"] = target_ns
+
+    # Rerender template
+    addon.sss = Sss(addon=addon)
+    walker = addon.sss.walker()
+    resources = walker["sss_delete"]["spec"]["resources"]
+
+    assert len(resources["Namespace"]) == 1
+    assert target_ns == resources["Namespace"][0][0]
+
+    assert len(resources["ConfigMap"]) == 1
+    assert target_ns == resources["ConfigMap"][0][1]["metadata"]["namespace"]
+
+
+# TODO
+# @given(hypothesis_strategies.data())
+# def test_pagerduty(data):
+#     pass

--- a/tests/testdata/addons/test-operator/metadata/integration/addon.yaml
+++ b/tests/testdata/addons/test-operator/metadata/integration/addon.yaml
@@ -1,0 +1,21 @@
+id: test-operator
+name: Test Operator
+description: Random operator to be deprecated as soon as Addon can be loaded without the filesystem
+link: https://github.com/mtsre/test-operator
+icon: invalid_icon
+label: api.openshift.com/addon-test-operator
+enabled: true
+addonOwner: MT-SRE Team <sd-mt-sre@redhat.com>
+quayRepo: quay.io/osd-addons/test-operator
+testHarness: quay.io/miwilson/test-operator
+installMode: OwnNamespace
+targetNamespace: redhat-test-operator
+namespaces:
+  - redhat-test-operator
+ocmQuotaName: test-operator
+ocmQuotaCost: 1
+operatorName: test-operator
+defaultChannel: alpha
+namespaceLabels: {}
+namespaceAnnotations: {}
+indexImage: quay.io/osd-addons/test-operator-index@sha256:8980b407722366080af758b138f438618912ce3270c72134273440c477653b56

--- a/tests/testdata/addons/test-operator/metadata/production/addon.yaml
+++ b/tests/testdata/addons/test-operator/metadata/production/addon.yaml
@@ -1,0 +1,21 @@
+id: test-operator
+name: Test Operator
+description: Random operator to be deprecated as soon as Addon can be loaded without the filesystem
+link: https://github.com/mtsre/test-operator
+icon: invalid_icon
+label: api.openshift.com/addon-test-operator
+enabled: true
+addonOwner: MT-SRE Team <sd-mt-sre@redhat.com>
+quayRepo: quay.io/osd-addons/test-operator
+testHarness: quay.io/miwilson/test-operator
+installMode: OwnNamespace
+targetNamespace: redhat-test-operator
+namespaces:
+  - redhat-test-operator
+ocmQuotaName: test-operator
+ocmQuotaCost: 1
+operatorName: test-operator
+defaultChannel: alpha
+namespaceLabels: {}
+namespaceAnnotations: {}
+indexImage: quay.io/osd-addons/test-operator-index@sha256:8980b407722366080af758b138f438618912ce3270c72134273440c477653b56

--- a/tests/testdata/addons/test-operator/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/test-operator/metadata/stage/addon.yaml
@@ -1,0 +1,21 @@
+id: test-operator
+name: Test Operator
+description: Random operator to be deprecated as soon as Addon can be loaded without the filesystem
+link: https://github.com/mtsre/test-operator
+icon: invalid_icon
+label: api.openshift.com/addon-test-operator
+enabled: true
+addonOwner: MT-SRE Team <sd-mt-sre@redhat.com>
+quayRepo: quay.io/osd-addons/test-operator
+testHarness: quay.io/miwilson/test-operator
+installMode: OwnNamespace
+targetNamespace: redhat-test-operator
+namespaces:
+  - redhat-test-operator
+ocmQuotaName: test-operator
+ocmQuotaCost: 1
+operatorName: test-operator
+defaultChannel: alpha
+namespaceLabels: {}
+namespaceAnnotations: {}
+indexImage: quay.io/osd-addons/test-operator-index@sha256:8980b407722366080af758b138f438618912ce3270c72134273440c477653b56

--- a/tests/testutils/paths.py
+++ b/tests/testutils/paths.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+TEST_ROOT = (Path(__file__) / ".." / "..").resolve()
+
+TEST_OPERATOR_PATH = TEST_ROOT / "testdata" / "addons" / "test-operator"
+
+CHECK_TASKS_DIR = (TEST_ROOT / ".." / "tasks" / "check").resolve()
+
+DEPLOY_TASKS_DIR = (TEST_ROOT / ".." / "tasks" / "deploy").resolve()

--- a/tests/testutils/strategies.py
+++ b/tests/testutils/strategies.py
@@ -1,0 +1,155 @@
+from copy import deepcopy
+from string import ascii_letters, ascii_lowercase, digits, punctuation
+
+from hypothesis import strategies as st
+from hypothesis_jsonschema import from_schema
+from managedtenants.core.addons_loader import Addon
+from managedtenants.data.environments import ENVIRONMENTS
+from managedtenants.utils.schema import load_addon_metadata_schema
+from tests.testutils.paths import TEST_OPERATOR_PATH
+
+
+def text(min_size=2, max_size=10, alphabet=None, **kwargs):
+    """Returns printable characters."""
+    default = ascii_letters + digits + punctuation + " "
+    return st.text(
+        min_size=min_size,
+        max_size=max_size,
+        alphabet=default if alphabet is None else alphabet,
+        **kwargs,
+    )
+
+
+def k8s_name(**kwargs):
+    """Returns a kubernetes friendly resource name."""
+    return text(alphabet=ascii_letters + "-", **kwargs)
+
+
+def namespace(**kwargs):
+    """Namespace need to match '^redhat-.*$'."""
+
+    def callback(ns):
+        return f"redhat-{ns}".lower()
+
+    return st.builds(callback, text(alphabet=ascii_letters + "-", **kwargs))
+
+
+def labels(min_size=1, max_size=5, **kwargs):
+    label_alphabet = ascii_lowercase + digits + "-" + "." + "/"
+
+    return st.dictionaries(
+        keys=text(alphabet=label_alphabet),
+        values=text(alphabet=label_alphabet),
+        min_size=min_size,
+        max_size=max_size,
+        **kwargs,
+    )
+
+
+def environment(**kwargs):
+    return st.sampled_from(list(ENVIRONMENTS.keys()), **kwargs)
+
+
+def addon(env):
+    return AddonStrategy(env)
+
+
+#
+# Helpers to build addon strategy
+#
+def build_addon_strategy_for_env(env):
+    """
+    Returns a custom hypothesis strategy to draw Addon from.
+    All addons are drawn from the same environment.
+
+    addon_id can't start with a number otherwise it breaks indexing when
+    present as a dictionary key.
+    """
+
+    def callback(env, labels, annotations, metadata):
+        """Callback used to patch addon metadata before injection in tests."""
+        addon = MockAddon(env)
+
+        # jsonschema object.items does not respect pattern field
+        metadata["namespaceAnnotations"] = annotations
+        metadata["namespaceLabels"] = labels
+
+        # TODO - when a pattern ends with '$' hypothesis adds a '\n', which
+        # breaks jinja2 templating. Using this solution as temporary fix.
+        fields_to_rstrip = [
+            "name",
+            "testHarness",
+            "label",
+            "ocmQuotaName",
+            "quayRepo",
+            "addonOwner",
+            "id",
+        ]
+        for f in fields_to_rstrip:
+            metadata[f] = metadata[f].rstrip()
+
+        addon.metadata = metadata
+        return addon
+
+    return st.builds(
+        callback,
+        env=st.just(env),
+        labels=labels(),
+        annotations=labels(),
+        metadata=from_schema(
+            get_fast_schema(),
+            # we define a custom format for non-unicode generation, this is
+            # because we use `yaml.load_safe(...)` which breaks on non-printable
+            # UTF-8. This format name must not override built-in jsonschema
+            # format names:
+            # https://json-schema.org/understanding-json-schema/reference/string.html#built-in-formats
+            custom_formats={
+                "printable": text(),
+            },
+        ),
+    )
+
+
+def get_fast_schema():
+    """Only generate required fields for fast testing."""
+    schema = load_addon_metadata_schema()
+    fast_schema = deepcopy(schema)
+
+    all_fields = set(fast_schema.get("properties").keys())
+    required_fields = set(fast_schema.get("required"))
+    optional_fields = all_fields - required_fields
+    for f in optional_fields:
+        fast_schema["properties"].pop(f, None)
+
+    return fast_schema
+
+
+class AddonStrategy:
+    """Singleton wrapper for addon hypothesis strategy."""
+
+    _instances = {env: None for env in ENVIRONMENTS}
+
+    def __new__(cls, env):
+        if env not in ENVIRONMENTS:
+            raise TypeError("Invalid environment.")
+
+        if cls._instances[env] is None:
+            cls._instances[env] = build_addon_strategy_for_env(env)
+        return cls._instances[env]
+
+
+class MockAddon:
+    """
+    Singleton wrapper for the mock addon.
+    Always returns a deepcopy so we start from a fresh addon.
+    """
+
+    _instances = {env: None for env in ENVIRONMENTS}
+
+    def __new__(cls, env):
+        if env not in ENVIRONMENTS:
+            raise TypeError("Invalid environment.")
+
+        if cls._instances[env] is None:
+            cls._instances[env] = Addon(TEST_OPERATOR_PATH, env)
+        return deepcopy(cls._instances[env])

--- a/tests/utils/test_schema.py
+++ b/tests/utils/test_schema.py
@@ -1,0 +1,44 @@
+from io import StringIO
+
+import pytest
+from jsonschema.exceptions import SchemaError
+from managedtenants.data.paths import DATA_DIR
+from managedtenants.utils.schema import (
+    AddonMetadataSchema,
+    load_addon_metadata_schema,
+    load_draft7_schema,
+)
+
+invalid_type_value = """
+---
+"$schema": "http://json-schema.org/draft-07/schema#"
+type: invalid
+"""
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        {"path_or_file": invalid_type_value, "raises": True},
+        {
+            "path_or_file": DATA_DIR / "metadata.schema.yaml",
+            "raises": False,
+        },
+    ],
+)
+def test_load_draft7_schema(case):
+    if case["raises"]:
+        with pytest.raises(SchemaError):
+            _ = load_draft7_schema(path_or_file=StringIO(case["path_or_file"]))
+    else:
+        assert isinstance(
+            load_draft7_schema(path_or_file=case["path_or_file"]), dict
+        )
+
+
+def test_load_addon_metadata_schema():
+    assert isinstance(load_addon_metadata_schema(), dict)
+
+
+def test_singleton_AddonMetadataSchema():
+    assert id(AddonMetadataSchema()) == id(AddonMetadataSchema())


### PR DESCRIPTION
`$ make lint` and `$ make test` work. :+1: 

Cherry-picked and adapted from  downstream `managed-tenants` repo.
