### PR TITLE
Fix metrics federation. SAN is required else prometheus complains. 

### DIFF
--- a/docs/tenants/zz_schema_generated.md
+++ b/docs/tenants/zz_schema_generated.md
@@ -58,7 +58,9 @@
 
   - **Items** *(string)*
 
-- **`monitoring`** *(object)*: Configuration parameters to be injected in the ServiceMonitor used for federation. The target prometheus server found by matchLabels needs to serve service-ca signed TLS traffic (https://docs.openshift.com/container-platform/4.6/security/certificate_types_descriptions/service-ca-certificates.html). Cannot contain additional properties.
+- **`monitoring`** *(object)*: Configuration parameters to be injected in the ServiceMonitor used for federation. The target prometheus server found by matchLabels needs to serve service-ca signed TLS traffic (https://docs.openshift.com/container-platform/4.6/security/certificate_types_descriptions/service-ca-certificates.html), and it needs to be runing inside the monitoring.namespace, with the service name 'prometheus'. Cannot contain additional properties.
+
+  - **`namespace`** *(string)*: Namespace where the prometheus server is running.
 
   - **`matchNames`** *(array)*: List of series names to federate from the prometheus server.
 

--- a/managedtenants/data/metadata.schema.yaml
+++ b/managedtenants/data/metadata.schema.yaml
@@ -99,12 +99,17 @@ properties:
     description: "Annotations to be applied to all objects created in the SelectorSyncSet."
   monitoring:
     type: object
-    description: "Configuration parameters to be injected in the ServiceMonitor used for federation. The target prometheus server found by matchLabels needs to serve service-ca signed TLS traffic (https://docs.openshift.com/container-platform/4.6/security/certificate_types_descriptions/service-ca-certificates.html)."
+    description: "Configuration parameters to be injected in the ServiceMonitor used for federation. The target prometheus server found by matchLabels needs to serve service-ca signed TLS traffic (https://docs.openshift.com/container-platform/4.6/security/certificate_types_descriptions/service-ca-certificates.html), and it needs to be runing inside the monitoring.namespace, with the service name 'prometheus'."
     additionalProperties: false
     required:
+      - namespace
       - matchNames
       - matchLabels
     properties:
+      namespace:
+        type: string
+        pattern: ^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$
+        description: "Namespace where the prometheus server is running."
       matchNames:
         type: array
         items:

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -126,6 +126,7 @@ items:
                 configMap:
                   name: openshift-service-ca.crt
                   key: service-ca.crt
+              serverName: prometheus.{{ ADDON.metadata['monitoring']['namespace'] }}.svc
             params:
               'match[]':
                 - ALERTS{alertstate="firing"}
@@ -134,9 +135,7 @@ items:
               {% endfor %}
         namespaceSelector:
           matchNames:
-          {% for namespace in ADDON.metadata['namespaces'] %}
-            - {{ namespace }}
-          {% endfor %}
+            - {{ ADDON.metadata['monitoring']['namespace'] }}
         selector:
           matchLabels:
             {{ expand_dict(ADDON.metadata['monitoring']['matchLabels']) | indent(12) }}

--- a/tests/sss/test_federated_metrics.py
+++ b/tests/sss/test_federated_metrics.py
@@ -12,6 +12,7 @@ def test_namespace_and_servicemonitor_v1(data):
     env = data.draw(custom_strategies.environment())
     addon = data.draw(custom_strategies.addon(env))
     addon.metadata["monitoring"] = {
+        "namespace": data.draw(custom_strategies.namespace()),
         "matchNames": data.draw(
             hypothesis_strategies.lists(custom_strategies.k8s_name())
         ),
@@ -36,8 +37,10 @@ def test_namespace_and_servicemonitor_v1(data):
     _, sm = walker["sss_deploy"]["spec"]["resources"]["ServiceMonitor"][0]
     assert sm["metadata"]["namespace"] == expected_ns_name
 
-    for ns in addon.metadata["namespaces"]:
-        assert ns in sm["spec"]["namespaceSelector"]["matchNames"]
+    assert (
+        addon.metadata["monitoring"]["namespace"]
+        == sm["spec"]["namespaceSelector"]["matchNames"][0]
+    )
 
     for matchName in addon.metadata["monitoring"]["matchNames"]:
         series_name = f"""'{{__name__="{matchName}"}}'"""


### PR DESCRIPTION
This came up in our RHODS debugging session with @erdii .

Please view: https://issues.redhat.com/browse/MTSRE-245 for more details.

Screenshot of the SAN error: 
![image](https://user-images.githubusercontent.com/20143605/136255862-84737c41-bdc3-4c7a-b913-4de5cc527274.png)
