### PR TITLE
Fix default value and provide better error message for --addons-dir flag.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
   ###
   # Flake8
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         args: ["--config", ".linters/flake8"]

--- a/managedtenants/cli/__init__.py
+++ b/managedtenants/cli/__init__.py
@@ -41,6 +41,7 @@ class Cli:
         parser.add_argument(
             "--addons-dir",
             type=self._validate_addons_dir,
+            required=True,
             help='[path] "path" for the addons directory',
         )
         parser.add_argument(
@@ -94,7 +95,10 @@ class Cli:
         addons_path = Path(value)
         if addons_path.is_dir():
             return value
-        raise argparse.ArgumentTypeError("not found: %s" % addons_path)
+        raise argparse.ArgumentTypeError(
+            f"The addons dir path: {addons_path} is invalid. Please provide a"
+            " valid addons_dir using '--addons-dir'."
+        )
 
     @staticmethod
     def _validate_tasks_reference(value):


### PR DESCRIPTION
When running the CLI to perform bundles migration, the following Traceback was shown:

```bash
$managedtenants --environment production --addon-name rhods run tasks/utils/10_pkgman_to_bundle.py
Traceback (most recent call last):
  File "/home/aasthana/go/src/github.com/managed-tenants/venv/bin/managedtenants", line 8, in <module>
    sys.exit(main())
  File "/home/aasthana/go/src/github.com/managed-tenants/venv/lib64/python3.9/site-packages/managedtenants/cli/__init__.py", line 188, in main
    cli.run()
  File "/home/aasthana/go/src/github.com/managed-tenants/venv/lib64/python3.9/site-packages/managedtenants/cli/__init__.py", line 128, in run
    self._run()
  File "/home/aasthana/go/src/github.com/managed-tenants/venv/lib64/python3.9/site-packages/managedtenants/cli/__init__.py", line 151, in _run
    addons_factory = self._load_addons()
  File "/home/aasthana/go/src/github.com/managed-tenants/venv/lib64/python3.9/site-packages/managedtenants/cli/__init__.py", line 131, in _load_addons
    addons_path = Path(self.args.addons_dir)
  File "/usr/lib64/python3.9/pathlib.py", line 1082, in __new__
    self = cls._from_parts(args, init=False)
  File "/usr/lib64/python3.9/pathlib.py", line 707, in _from_parts
    drv, root, parts = self._parse_args(args)
  File "/usr/lib64/python3.9/pathlib.py", line 691, in _parse_args
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
This happened because `Path(None)` was run.

Fixing `NoneType` -> to be "addons" by default, and also sending a more error-friendly error