### PR TITLE
add versionedmetadata schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
   ###
   # Flake8
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         args: ["--config", ".linters/flake8"]

--- a/docs/tenants/zz_imageset_schema_generated.md
+++ b/docs/tenants/zz_imageset_schema_generated.md
@@ -4,7 +4,7 @@
 ## Properties
 
 
-- **`name`** *(string)*: The name of the imageset along with the version.
+- **`name`** *(string)*: The name of the imageset along with the version: Needs to match: <name>.<version>.
 
 - **`indexImage`** *(string)*: The url for the index image.
 

--- a/managedtenants/data/imageset.schema.yaml
+++ b/managedtenants/data/imageset.schema.yaml
@@ -4,7 +4,7 @@ additionalProperties: false
 properties:
   name:
     type: string
-    description: "The name of the imageset along with the version"
+    description: "The name of the imageset along with the version: Needs to match: <name>.<version>"
   indexImage:
     type: string
     pattern: ^quay\.io/osd-addons/[a-z-]+

--- a/managedtenants/data/versionedmetadata.schema.yaml
+++ b/managedtenants/data/versionedmetadata.schema.yaml
@@ -1,0 +1,194 @@
+type: object
+additionalProperties: false
+properties:
+  name:
+    type: string
+    description: "The name of the addon along with the version: Needs to match: <name>.<version>"
+  addOnParameters:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - description
+        - value_type
+        - required
+        - editable
+        - enabled
+      properties:
+        id:
+          type: string
+          format: printable
+        name:
+          type: string
+          format: printable
+        description:
+          type: string
+          format: printable
+        value_type:
+          type: string
+          enum:
+            - string
+            - number
+            - boolean
+            - cidr
+            - resource
+        validation:
+          type: string
+          format: printable
+        required:
+          type: boolean
+        editable:
+          type: boolean
+        enabled:
+          type: boolean
+        default_value:
+          type: string
+          format: printable
+        options:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - name
+              - value
+            properties:
+              name:
+                type: string
+                format: printable
+              value:
+                type: string
+                format: printable
+        conditions:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - resource
+              - data
+            properties:
+              resource:
+                type: string
+                enum:
+                  - cluster
+              data:
+                type: object
+                additionalProperties: false
+                properties:
+                  aws.sts.enabled:
+                    type: boolean
+                  ccs.enabled:
+                    type: boolean
+                  cloud_provider.id:
+                    type:
+                      - array
+                      - string
+                    items:
+                      type: string
+                      format: printable
+                  product.id:
+                    type:
+                      - array
+                      - string
+                    items:
+                      type: string
+                      format: printable
+                  version.raw_id:
+                    type: string
+                    format: printable
+  addOnRequirements:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - resource
+        - data
+        - enabled
+      properties:
+        id:
+          type: string
+          format: printable
+        resource:
+          type: string
+          enum:
+            - cluster
+            - addon
+            - machine_pool
+        data:
+          type: object
+          additionalProperties: false
+          properties:
+            id:
+              type: string
+              format: printable
+            #AddOn
+            state:
+              type: string
+              format: printable
+            #Cluster
+            aws.sts.enabled:
+              type: boolean
+            cloud_provider.id:
+              type:
+                - array
+                - string
+              items:
+                type: string
+                format: printable
+            product.id:
+              type:
+                - array
+                - string
+              items:
+                type: string
+                format: printable
+            compute.memory:
+              type: integer
+            compute.cpu:
+              type: integer
+            ccs.enabled:
+              type: boolean
+            nodes.compute:
+              type: integer
+            nodes.compute_machine_type.id:
+              type:
+                - array
+                - string
+              format: printable
+            version.raw_id:
+              type: string
+              format: printable
+            #MachinePool
+            instance_type:
+              type:
+                - array
+                - string
+              format: printable
+            replicas:
+              type: integer
+        enabled:
+          type: boolean
+  subOperators:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - operatorName
+        - operatorNamespace
+        - enabled
+      properties:
+        operator_name:
+          type: string
+          format: printable
+        operator_namespace:
+          type: string
+          format: printable
+        enabled:
+          type: boolean

--- a/managedtenants/utils/schema.py
+++ b/managedtenants/utils/schema.py
@@ -19,6 +19,10 @@ def load_addon_imageset_schema():
     return SchemaLoader("imageset")
 
 
+def load_addon_versionedmeta_schema():
+    return SchemaLoader("versionedmetadata")
+
+
 # Accept path or file for easier testing
 def load_draft7_schema(path_or_file):
     """


### PR DESCRIPTION
To adapt to the new OCM API changes, this PR adds support for versioning metadata fields such as `addonParameters`, `addonRequirements` and `sub-operators`. Versioning for these files shall be managed in a separate directory within the addon folder, called `versionedmetadata/`.

```
└── my-addon
    ├── imagesets
    │   ├── production
    │   │   ├── my-addon.0.0.1.yaml
    │   │   └── my-addon.0.0.2.yaml
    │   └── stage
    │       ├── my-addon.0.0.1.yaml
    │       └── my-addon.0.0.2.yaml
    ├── metadata
    │   ├── production
    │   │   └── addon.yaml
    │   └── stage
    │       └── addon.yaml
    └── versionedmetadata
        ├── production
        │   ├── my-addon.0.0.1.yaml
        │   └── my-addon.0.0.2.yaml
        └── stage
            ├── my-addon.0.0.1.yaml
            └── my-addon.0.0.2.yaml
```

These files will be versioned according to the imageset versioning, i.e, the `addonImagesetVersion` in `addon.yaml` shall now correspond to the imageset as well as the versioned metadata.

Sample versioned metadata file:

```yaml
# addons/ocd-converged/versionedmetadata/ocs-osd-deployer.1.1.1.yaml
name: ocs-osd-deployer.1.1.1
addOnRequirements:
- resource: cluster
  id: cluster-requirements
  enabled: true
  data:
    ccs.enabled: true
    cloud_provider.id: aws
    compute.memory: 53687091200
    compute.cpu: 20
    nodes.compute: 3
addOnParameters:
- id: size
  name: Managed StorageCluster size
  description: The size, in terabytes, of the Storage Cluster to be deployed. Currently
    1 or 4 are supported.
  value_type: string
  options:
  - name: 1 TiB
    value: '1'
  - name: 4 TiB
    value: '4'
  required: true
  editable: true
  enabled: true
  default_value: '1'
- id: notification-email-0
  name: Notification Email
  description: An email address for storage lifecycle notifications.
  value_type: string
  validation: |-
    (?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])
  required: false
  editable: true
  enabled: true

```

To maintain backwards compatibility, these fields shall continue to work within the `addon.yaml` as well, unless a `versionedmetadata` directory exists for the addon. 



Signed-off-by: Mayank Shah <m.shah@redhat.com>