### PR TITLE
Bump OCM retries to 10 attempts instead of 3.

### DIFF
--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -56,7 +56,7 @@ class OcmCli:
             self.api = api
 
     @property
-    @retry(hook=retry_hook)
+    @retry(hook=retry_hook, max_attempts=10)
     def token(self):
         now = datetime.utcnow()
         if self._token:


### PR DESCRIPTION
To make CI more robust, let's re-attempt OCM requests more aggressively.