### PR TITLE
[MTSRE-214]: Update imageset schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,13 +30,13 @@ repos:
       - id: trailing-whitespace
   # Black
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.10b0
     hooks:
       - id: black
         args: ["--config", ".linters/black", "--experimental-string-processing"]
   # isort
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
       - id: isort
         args: ["--profile", "black", "-l", "80"]

--- a/docs/tenants/zz_imageset_schema_generated.md
+++ b/docs/tenants/zz_imageset_schema_generated.md
@@ -11,3 +11,107 @@
 - **`relatedImages`** *(array)*: A list of image urls of related operators.
 
   - **Items** *(string)*
+
+- **`addOnParameters`** *(array)*
+
+  - **Items** *(object)*: Cannot contain additional properties.
+
+    - **`id`** *(string)*
+
+    - **`name`** *(string)*
+
+    - **`description`** *(string)*
+
+    - **`value_type`** *(string)*: Must be one of: `['string', 'number', 'boolean', 'cidr', 'resource']`.
+
+    - **`validation`** *(string)*
+
+    - **`required`** *(boolean)*
+
+    - **`editable`** *(boolean)*
+
+    - **`enabled`** *(boolean)*
+
+    - **`default_value`** *(string)*
+
+    - **`options`** *(array)*
+
+      - **Items** *(object)*: Cannot contain additional properties.
+
+        - **`name`** *(string)*
+
+        - **`value`** *(string)*
+
+    - **`conditions`** *(array)*
+
+      - **Items** *(object)*: Cannot contain additional properties.
+
+        - **`resource`** *(string)*: Must be one of: `['cluster']`.
+
+        - **`data`** *(object)*: Cannot contain additional properties.
+
+          - **`aws.sts.enabled`** *(boolean)*
+
+          - **`ccs.enabled`** *(boolean)*
+
+          - **`cloud_provider.id`** *(['array', 'string'])*
+
+            - **Items** *(string)*
+
+          - **`product.id`** *(['array', 'string'])*
+
+            - **Items** *(string)*
+
+          - **`version.raw_id`** *(string)*
+
+- **`addOnRequirements`** *(array)*
+
+  - **Items** *(object)*: Cannot contain additional properties.
+
+    - **`id`** *(string)*
+
+    - **`resource`** *(string)*: Must be one of: `['cluster', 'addon', 'machine_pool']`.
+
+    - **`data`** *(object)*: Cannot contain additional properties.
+
+      - **`id`** *(string)*
+
+      - **`state`** *(string)*
+
+      - **`aws.sts.enabled`** *(boolean)*
+
+      - **`cloud_provider.id`** *(['array', 'string'])*
+
+        - **Items** *(string)*
+
+      - **`product.id`** *(['array', 'string'])*
+
+        - **Items** *(string)*
+
+      - **`compute.memory`** *(integer)*
+
+      - **`compute.cpu`** *(integer)*
+
+      - **`ccs.enabled`** *(boolean)*
+
+      - **`nodes.compute`** *(integer)*
+
+      - **`nodes.compute_machine_type.id`** *(['array', 'string'])*
+
+      - **`version.raw_id`** *(string)*
+
+      - **`instance_type`** *(['array', 'string'])*
+
+      - **`replicas`** *(integer)*
+
+    - **`enabled`** *(boolean)*
+
+- **`subOperators`** *(array)*
+
+  - **Items** *(object)*: Cannot contain additional properties.
+
+    - **`operator_name`** *(string)*
+
+    - **`operator_namespace`** *(string)*
+
+    - **`enabled`** *(boolean)*

--- a/managedtenants/data/imageset.schema.yaml
+++ b/managedtenants/data/imageset.schema.yaml
@@ -14,7 +14,194 @@ properties:
     description: "A list of image urls of related operators"
     items:
       type: string
-
+  addOnParameters:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - description
+        - value_type
+        - required
+        - editable
+        - enabled
+      properties:
+        id:
+          type: string
+          format: printable
+        name:
+          type: string
+          format: printable
+        description:
+          type: string
+          format: printable
+        value_type:
+          type: string
+          enum:
+            - string
+            - number
+            - boolean
+            - cidr
+            - resource
+        validation:
+          type: string
+          format: printable
+        required:
+          type: boolean
+        editable:
+          type: boolean
+        enabled:
+          type: boolean
+        default_value:
+          type: string
+          format: printable
+        options:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - name
+              - value
+            properties:
+              name:
+                type: string
+                format: printable
+              value:
+                type: string
+                format: printable
+        conditions:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - resource
+              - data
+            properties:
+              resource:
+                type: string
+                enum:
+                  - cluster
+              data:
+                type: object
+                additionalProperties: false
+                properties:
+                  aws.sts.enabled:
+                    type: boolean
+                  ccs.enabled:
+                    type: boolean
+                  cloud_provider.id:
+                    type:
+                      - array
+                      - string
+                    items:
+                      type: string
+                      format: printable
+                  product.id:
+                    type:
+                      - array
+                      - string
+                    items:
+                      type: string
+                      format: printable
+                  version.raw_id:
+                    type: string
+                    format: printable
+  addOnRequirements:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - resource
+        - data
+        - enabled
+      properties:
+        id:
+          type: string
+          format: printable
+        resource:
+          type: string
+          enum:
+            - cluster
+            - addon
+            - machine_pool
+        data:
+          type: object
+          additionalProperties: false
+          properties:
+            id:
+              type: string
+              format: printable
+            #AddOn
+            state:
+              type: string
+              format: printable
+            #Cluster
+            aws.sts.enabled:
+              type: boolean
+            cloud_provider.id:
+              type:
+                - array
+                - string
+              items:
+                type: string
+                format: printable
+            product.id:
+              type:
+                - array
+                - string
+              items:
+                type: string
+                format: printable
+            compute.memory:
+              type: integer
+            compute.cpu:
+              type: integer
+            ccs.enabled:
+              type: boolean
+            nodes.compute:
+              type: integer
+            nodes.compute_machine_type.id:
+              type:
+                - array
+                - string
+              format: printable
+            version.raw_id:
+              type: string
+              format: printable
+            #MachinePool
+            instance_type:
+              type:
+                - array
+                - string
+              format: printable
+            replicas:
+              type: integer
+        enabled:
+          type: boolean
+  subOperators:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - operatorName
+        - operatorNamespace
+        - enabled
+      properties:
+        operator_name:
+          type: string
+          format: printable
+        operator_namespace:
+          type: string
+          format: printable
+        enabled:
+          type: boolean
 required:
   - name
   - indexImage


### PR DESCRIPTION
The CPaaS team has agreed to provide the required fields for addon versioning as a part of imageset.

This PR adds addonRequirements, addonParameters and subOperators to imageset.

Addons such as RHOAMS currently cannot be migrated to mt-bundles and hence we're required to still keep these params in metadata as well.

Signed-off-by: Mayank Shah <m.shah@redhat.com>