### PR TITLE
[MTSRE-295] Add --only-changed flag to modify the addons_loader behavior and speedup pipeline.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,13 +30,13 @@ repos:
       - id: trailing-whitespace
   # Black
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.10b0
     hooks:
       - id: black
         args: ["--config", ".linters/black", "--experimental-string-processing"]
   # isort
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
       - id: isort
         args: ["--profile", "black", "-l", "80"]

--- a/managedtenants/cli/__init__.py
+++ b/managedtenants/cli/__init__.py
@@ -53,6 +53,21 @@ class Cli:
             default=False,
             help="Allow Insecure connection to OCM API",
         )
+        parser.add_argument(
+            "--only-changed",
+            action="store_true",
+            default=False,
+            help=(
+                "Modifies the addons_loader to only consider addons with"
+                " changed files"
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Flag to specify a non-invasive execution",
+        )
 
         subcommands = parser.add_subparsers(
             title="subcommands", help="subcommand help", dest="subcommand"
@@ -69,12 +84,6 @@ class Cli:
                 'or file and "search" string to filter '
                 "tasks"
             ),
-        )
-        run_parser.add_argument(
-            "--dry-run",
-            action="store_true",
-            default=False,
-            help="Flag to the tasks that this is a non-invasive execution",
         )
         run_parser.add_argument(
             "--debug",
@@ -140,6 +149,7 @@ class Cli:
                 path=addons_path,
                 environment=self.args.environment,
                 addon_name=addon_name,
+                args=self.args,
             )
             APP_LOG.info("Loading %s OK", self.args.environment)
             return addons_factory

--- a/managedtenants/core/addons_loader/__init__.py
+++ b/managedtenants/core/addons_loader/__init__.py
@@ -1,25 +1,38 @@
 from managedtenants.core.addons_loader.addon import Addon
+from managedtenants.utils.git import ChangeDetector
 
 
 def instantiate_addon(args):
     return Addon(path=args[0], environment=args[1])
 
 
-def load_addons(path, environment, addon_name):
+def load_addons(path, environment, addon_name, args):
     addons_to_load = []
-    for item in sorted(path.iterdir()):
+
+    for candidate in get_candidates(path, args):
         if addon_name is not None:
-            if item.name != addon_name:
+            if candidate.name != addon_name:
                 continue
-        envs_path = item / "metadata"
+        envs_path = candidate / "metadata"
         for env_path in sorted(envs_path.iterdir()):
             # Filtering out the other environments
             if env_path.name != environment:
                 continue
-            addons_to_load.append((item, environment))
+            addons_to_load.append((candidate, environment))
 
     if not addons_to_load:
         return []
 
     # force list to not lazily evaluate the returned iterator of map()
     return list(map(instantiate_addon, addons_to_load))
+
+
+def get_candidates(path, args):
+    """
+    Filter potential addon candidates to be loaded or acted upon.
+    """
+    if args.only_changed:
+        cd = ChangeDetector(addons_dir=path, dry_run=args.dry_run)
+        return sorted(cd.get_changed_addons())
+
+    return sorted(path.iterdir())

--- a/managedtenants/utils/git.py
+++ b/managedtenants/utils/git.py
@@ -1,0 +1,76 @@
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+
+class ChangeDetector:
+    def __init__(self, addons_dir, dry_run=True):
+        self.dry_run = dry_run
+        self.addons_dir = addons_dir
+        self.log = logging.getLogger("app")
+
+    def get_changed_addons(self):
+        """
+        Get the list of all changed addons.
+        """
+        addons_dir = Path(self.addons_dir).resolve()
+        all_addons = set(addons_dir.iterdir())
+        changed_files = self._get_changed_files()
+        return self._intersect(parents=all_addons, children=changed_files)
+
+    @staticmethod
+    def _intersect(parents, children):
+        """
+        Abstraction to find all parents that have at least a child path listed
+        in children.
+
+        :param parents: set of parent directories
+        :param children: set of child paths
+        """
+        res = set()
+        for child in children:
+            match = set(child.parents).intersection(parents)
+
+            # If match is already in res this is a no-op
+            res.update(match)
+
+        return res
+
+    def _get_changed_files(self):
+        """
+        Detect changed files within managed-tenants and managed-tenants-bundles.
+
+        Remote name has to be origin and principal branch called main, which is
+        the case for both repositories.
+        """
+        if self.dry_run:
+            # pr_check
+            commit_range = "remotes/origin/main...HEAD"
+        else:
+            # build_deploy
+            # From https://plugins.jenkins.io/git/
+            git_previous_commit = os.environ["GIT_PREVIOUS_COMMIT"]
+            git_commit = os.environ["GIT_COMMIT"]
+            commit_range = f"{git_previous_commit}...{git_commit}"
+
+        changed_files = set()
+        cmd = [
+            "git",
+            "diff",
+            "--name-only",
+            f"{commit_range}",
+        ]
+        result = self._run(cmd).stdout.decode().strip()
+        for diff in result.splitlines():
+            changed_files.add(Path(diff).resolve())
+        return changed_files
+
+    def _run(self, cmd):
+        """
+        Calls subprocess.run with select options.
+        """
+        self.log.debug("Running %s", cmd)
+        return subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
+        )

--- a/tests/utils/test_change_detector.py
+++ b/tests/utils/test_change_detector.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import pytest
+
+from managedtenants.utils.git import ChangeDetector
+
+ROOT = Path("/addons")
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {
+            "parents": set(
+                [
+                    ROOT / "addon-one",
+                    ROOT / "addon-two",
+                    ROOT / "addon-three",
+                ]
+            ),
+            "children": set(
+                [
+                    ROOT / "addon-one/some/file",
+                    ROOT / "addon-one/another/file",
+                ]
+            ),
+            "expected": set([ROOT / "addon-one"]),
+        },
+        {
+            "parents": set(
+                [
+                    ROOT / "addon-one",
+                    ROOT / "addon-two",
+                    ROOT / "addon-three",
+                ]
+            ),
+            "children": set(
+                [
+                    ROOT / "addon-one/some/file",
+                    ROOT / "addon-two/another/file",
+                    ROOT / "addon-three/yippy",
+                ]
+            ),
+            "expected": set(
+                [
+                    ROOT / "addon-one",
+                    ROOT / "addon-two",
+                    ROOT / "addon-three",
+                ]
+            ),
+        },
+        {
+            "parents": set(
+                [
+                    ROOT / "addon-one",
+                    ROOT / "addon-two",
+                    ROOT / "addon-three",
+                ]
+            ),
+            "children": set(
+                [
+                    ROOT / "addon-four/some/file",
+                    ROOT / "addon-five/another/file",
+                    ROOT / "addon-six/yippy",
+                ]
+            ),
+            "expected": set(),
+        },
+    ],
+)
+def test_change_detector_intersect(data):
+    cd = ChangeDetector(addons_dir="unused")
+    got = cd._intersect(data["parents"], data["children"])
+
+    assert len(got) == len(data["expected"])
+    for e in data["expected"]:
+        assert e in got


### PR DESCRIPTION
In an effort to reduce our bundles-to-prod deployment time, adding this piece of code to modify the `addons_loader`.

# TODO after merging

- [ ] Modify `managedtenants` CLI command (and maybe docs) as the `--dry-run` flag now needs to be placed **BEFORE** any subcommand (`load` or `run`)
- [ ] Modify `Makefile` target and add  `--only-changed` flag