### PR TITLE
[MTSRE-303] Allow subscription configs to be created

### DIFF
--- a/docs/tenants/zz_schema_generated.md
+++ b/docs/tenants/zz_schema_generated.md
@@ -223,3 +223,13 @@
     - **`operator_namespace`** *(string)*
 
     - **`enabled`** *(boolean)*
+
+- **`config`** *(object)*: Cannot contain additional properties.
+
+  - **`env`** *(array)*
+
+    - **Items** *(object)*: Cannot contain additional properties.
+
+      - **`name`** *(string)*
+
+      - **`value`** *(string)*

--- a/docs/tenants/zz_schema_generated.md
+++ b/docs/tenants/zz_schema_generated.md
@@ -224,9 +224,9 @@
 
     - **`enabled`** *(boolean)*
 
-- **`config`** *(object)*: Cannot contain additional properties.
+- **`config`** *(object)*: Configs to be passed to the subscription OLM object. Cannot contain additional properties.
 
-  - **`env`** *(array)*
+  - **`env`** *(array)*: Array of environment variables (name, value pair) to be created as part of the subscription object.
 
     - **Items** *(object)*: Cannot contain additional properties.
 

--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -21,7 +21,7 @@ from managedtenants.utils.schema import (
 # These addon IDs _MUST_ be stable and not changed or bad things will happen
 # (this applies to addon IDs in general, but it's worth pointing out here, too)
 _ADDON_OPERATOR_ADDON_IDS = ["reference-addon"]
-_PERMITTED_SUBSCRIPTION_CONFIGS = {"env"}
+_PERMITTED_SUBSCRIPTION_CONFIGS = ["env"]
 
 
 class Addon:
@@ -107,9 +107,11 @@ class Addon:
     def _validate_subscription_config(self, metadata):
         if not metadata.get("config"):
             return
-        configs_present = set(metadata["config"].keys())
+        configs_present = metadata["config"]
         # configs_present should be a subset of _PERMITTED_SUBSCRIPTION_CONFIGS
-        if not configs_present <= _PERMITTED_SUBSCRIPTION_CONFIGS:
+        for item in configs_present:
+            if item in _PERMITTED_SUBSCRIPTION_CONFIGS:
+                continue
             raise AddonLoadError(
                 f"{self.path} validation error: "
                 "Unsupported subscription config objects"

--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -21,6 +21,7 @@ from managedtenants.utils.schema import (
 # These addon IDs _MUST_ be stable and not changed or bad things will happen
 # (this applies to addon IDs in general, but it's worth pointing out here, too)
 _ADDON_OPERATOR_ADDON_IDS = ["reference-addon"]
+_PERMITTED_SUBSCRIPTION_CONFIGS = {"env"}
 
 
 class Addon:
@@ -64,6 +65,9 @@ class Addon:
     def name(self):
         return self.path.name
 
+    def subscription_config_present(self):
+        return self.metadata.get("config") is not None
+
     def get_image_name(self, environment):
         """
         Creates a deterministic image name that is unique per
@@ -93,11 +97,25 @@ class Addon:
 
         self._validate_schema(metadata)
         self._validate_extra_resources(environment, metadata)
+        self._validate_subscription_config(metadata)
 
         if "extraResources" in metadata:
             self.extra_resources_loader = FileSystemLoader(str(metadata_dir))
 
         return metadata
+
+    def _validate_subscription_config(self, metadata):
+        if not metadata.get("config"):
+            return
+        configs_present = set(metadata["config"].keys())
+        # configs_present should be a subset of _PERMITTED_SUBSCRIPTION_CONFIGS
+        if not configs_present <= _PERMITTED_SUBSCRIPTION_CONFIGS:
+            raise AddonLoadError(
+                f"{self.path} validation error: "
+                "Unsupported subscription config objects"
+                "present!. Supported values are:"
+                f"{_PERMITTED_SUBSCRIPTION_CONFIGS}"
+            )
 
     def load_imageset(self, imageset_version):
         if not version_parsable(imageset_version):

--- a/managedtenants/data/metadata.schema.yaml
+++ b/managedtenants/data/metadata.schema.yaml
@@ -406,12 +406,14 @@ properties:
           type: boolean
   config:
     type: object
+    description: "Configs to be passed to the subscription OLM object"
     additionalProperties: false
     required:
       - env
     properties:
       env:
         type: array
+        description: "Array of environment variables (name, value pair) to be created as part of the subscription object"
         items:
           type: object
           additionalProperties: false

--- a/managedtenants/data/metadata.schema.yaml
+++ b/managedtenants/data/metadata.schema.yaml
@@ -404,6 +404,28 @@ properties:
           format: printable
         enabled:
           type: boolean
+  config:
+    type: object
+    additionalProperties: false
+    required:
+      - env
+    properties:
+      env:
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          required:
+            - name
+            - value
+          properties:
+            name:
+              type: string
+              format: printable
+            value:
+              type: string
+              format: printable
+
 required:
   - id
   - name

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -94,10 +94,10 @@ items:
         name: {{ADDON.metadata['id']}}
         source: addon-{{ADDON.metadata['id']}}-catalog
         sourceNamespace: openshift-marketplace
-        {% if ADDON.metadata.get('config') %}
+        {% if ADDON.subscription_config_present() %}
         config:
           env:
-          {% for env_obj in ADDON.metadata['config'].get('env', []) %}
+          {% for env_obj in ADDON.metadata['config']['env'] %}
           - name: {{env_obj['name']}}
             value: {{env_obj['value']}}
           {% endfor %}

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -94,6 +94,15 @@ items:
         name: {{ADDON.metadata['id']}}
         source: addon-{{ADDON.metadata['id']}}-catalog
         sourceNamespace: openshift-marketplace
+        {% if ADDON.metadata.get('config') %}
+        config:
+          env:
+          {% for env_obj in ADDON.metadata['config'].get('env', []) %}
+          - name: {{env_obj['name']}}
+            value: {{env_obj['value']}}
+          {% endfor %}
+        {% endif %}
+
 {% if ADDON.metadata['manualInstallPlanApproval'] is defined and ADDON.metadata['manualInstallPlanApproval'] %}
         installPlanApproval: Manual
 {% endif %}

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -11,6 +11,7 @@ from tests.testutils.addon_helpers import (  # flake8: noqa: F401
     ADDON_WITH_IMAGESET_TYPE,
     addon_metadata_with_imageset_version,
     addon_with_imageset_path,
+    addon_with_indeximage_path,
     load_yaml,
     setup_addon_class_with_stubbed_metadata,
 )
@@ -126,3 +127,18 @@ def test_raises_imageset_missing_error():
     addon.imagesets_path = addon.path / "addonimagesets/prod"
     with pytest.raises(AddonLoadError):
         addon.load_imageset(addon.imageset_version)
+
+
+def test_addon_subscription_config():
+    addon = Addon(addon_with_indeximage_path(), "stage")
+    res = addon.metadata["config"].get("env")
+    assert res is not None
+    assert res == [
+        {"name": "LOCATION", "value": "Black Mesa Research Facility"},
+        {"name": "USER", "value": "Gordon Freeman"},
+    ]
+
+    updated_metadata = addon.metadata
+    updated_metadata["config"]["unsupportedAttr"] = "present"
+    with pytest.raises(AddonLoadError):
+        addon._validate_subscription_config(updated_metadata)

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -132,7 +132,6 @@ def test_raises_imageset_missing_error():
 def test_addon_subscription_config():
     addon = Addon(addon_with_indeximage_path(), "stage")
     res = addon.metadata["config"].get("env")
-    assert res is not None
     assert res == [
         {"name": "LOCATION", "value": "Black Mesa Research Facility"},
         {"name": "USER", "value": "Gordon Freeman"},

--- a/tests/sss/test_subscription_config.py
+++ b/tests/sss/test_subscription_config.py
@@ -1,0 +1,32 @@
+import pytest
+
+from tests.testutils.addon_helpers import addon_with_imageset  # noqa: F401
+from tests.testutils.addon_helpers import addon_with_indeximage  # noqa: F401
+
+
+@pytest.mark.parametrize(
+    "addon_str",
+    [
+        "addon_with_indeximage",
+        "addon_with_imageset",
+    ],
+)
+def test_subscription_config(addon_str, request):
+    expected_values = [
+        {"name": "LOCATION", "value": "Black Mesa Research Facility"},
+        {"name": "USER", "value": "Gordon Freeman"},
+    ]
+    addon = request.getfixturevalue(addon_str)
+    sss_walker = addon.sss.walker()
+    subscription_obj = sss_walker["sss_deploy"]["spec"]["resources"][
+        "Subscription"
+    ][0]
+    if addon.subscription_config_present():
+        _, subscription_contents = subscription_obj
+        assert len(subscription_contents["spec"]["config"]["env"]) == 2
+        for env_obj in subscription_contents["spec"]["config"]["env"]:
+            assert env_obj in expected_values
+    else:
+        _, subscription_contents = subscription_obj
+        res = subscription_contents["spec"].get("config")
+        assert res is None

--- a/tests/testdata/addons/test-operator/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/test-operator/metadata/stage/addon.yaml
@@ -19,3 +19,9 @@ defaultChannel: alpha
 namespaceLabels: {}
 namespaceAnnotations: {}
 indexImage: quay.io/osd-addons/test-operator-index@sha256:8980b407722366080af758b138f438618912ce3270c72134273440c477653b56
+config:
+  env:
+  - name: LOCATION
+    value: Black Mesa Research Facility
+  - name: USER
+    value: Gordon Freeman


### PR DESCRIPTION
This PR allows tenants to create subscription configs for their addons by specifying them in the addon metadata file. (addon.yaml file) 

Todo after this is merged: 
- Update docs