### PR TITLE
ocm: Fix addon version patch operation

### DIFF
--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -116,7 +116,7 @@ class OcmCli:
 
     def update_addon_version(self, imageset, metadata):
         addon = self._addon_from_imageset(imageset, metadata)
-        version_id = addon.get("id")
+        version_id = addon.pop("id")
         addon_name = metadata.get("id")
         return self._patch(
             f"/api/clusters_mgmt/v1/addons/{addon_name}/versions/{version_id}",


### PR DESCRIPTION
This PR removed the `id` field from the payload while executing a PATCH operation against the OCM versions API. This would otherwise lead to the following error:

```
original error: {"kind":"Error","id":"400","href":"/api/clusters_mgmt/v1/errors/400","code":"CLUSTERS-MGMT-400","reason":"The following attributes are not allowed: 'id'","operation_id":"49b91421-924c-4cef-a2ed-020f3a34dfa1"}
```

This fix has been tested locally against the OCM API.

Signed-off-by: Mayank Shah <m.shah@redhat.com>