### PR TITLE
Parse imageset version from imageset name for OCM upsert

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: trailing-whitespace
   # Black
   - repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 21.12b0
     hooks:
       - id: black
         args: ["--config", ".linters/black", "--experimental-string-processing"]

--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -11,6 +11,7 @@ from managedtenants.core.addons_loader.bundle import Bundle
 from managedtenants.core.addons_loader.exceptions import AddonLoadError
 from managedtenants.core.addons_loader.package import Package
 from managedtenants.core.addons_loader.sss import Sss
+from managedtenants.utils.general_utils import parse_version_from_imageset_name
 from managedtenants.utils.hash import hash_dir_sha256, hash_sha256
 from managedtenants.utils.schema import (
     load_addon_imageset_schema,
@@ -139,7 +140,7 @@ class Addon:
         target_version = self.imageset_version
 
         def get_version(imageset_yaml):
-            return parse_image_version_from_name(
+            return parse_version_from_imageset_name(
                 name=imageset_yaml.get("name", "")
             )
 
@@ -258,17 +259,6 @@ def find(iterator, item, key_func=None):
         return arg == item
 
     return next(filter(predicate, iterator), None)
-
-
-def parse_image_version_from_name(name):
-    """Returns the image version from the name.
-    Ex: mock-operator.v1.0.0 -> 1.0.0"""
-    version_str = name.split(".v")[-1]
-    try:
-        result = semver.VersionInfo.parse(version_str)
-        return result
-    except ValueError:
-        return None
 
 
 def version_parsable(imageset_version):

--- a/managedtenants/utils/general_utils.py
+++ b/managedtenants/utils/general_utils.py
@@ -1,5 +1,18 @@
 import subprocess
 
+import semver
+
+
+def parse_version_from_imageset_name(name):
+    """Returns the image version from the name.
+    Ex: mock-operator.v1.0.0 -> 1.0.0"""
+    version_str = name.split(".v")[-1]
+    try:
+        result = semver.VersionInfo.parse(version_str)
+        return result
+    except ValueError:
+        return None
+
 
 def run(cmd, logger=None):
     """

--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -4,6 +4,8 @@ from datetime import datetime, timedelta
 import requests
 from sretoolbox.utils import retry
 
+from managedtenants.utils.general_utils import parse_version_from_imageset_name
+
 
 class OCMAPIError(Exception):
     """Used when there are errors with the OCM API"""
@@ -163,7 +165,7 @@ class OcmCli:
     # to an ImageSet
     def _addon_from_imageset(self, imageset, metadata):
         addon = {
-            "id": metadata.get("addonImageSetVersion"),
+            "id": str(parse_version_from_imageset_name(imageset.get("name"))),
             "enabled": metadata.get("enabled"),
         }
 


### PR DESCRIPTION
The current approach is to use `metadata.addonImageSetVersion`. However, the problem with this is that the said field could be set to `latest`, which causes issues when posting data to OCM, as `latest` is not recognized as a version. Instead, this PR parses the version directly from the imageset name instead of relying on what is set in the metadata

Signed-off-by: Mayank Shah <m.shah@redhat.com>