### PR TITLE
Make imageset.addOnParameters consistent with metadata.addOnParameters

### DIFF
--- a/docs/tenants/zz_imageset_schema_generated.md
+++ b/docs/tenants/zz_imageset_schema_generated.md
@@ -12,59 +12,57 @@
 
   - **Items** *(string)*
 
-- **`addOnParameters`** *(object)*: List of Addon Parameters. Cannot contain additional properties.
+- **`addOnParameters`** *(array)*
 
-  - **`items`** *(array)*
+  - **Items** *(object)*: Cannot contain additional properties.
 
-    - **Items** *(object)*: Cannot contain additional properties.
+    - **`id`** *(string)*
 
-      - **`id`** *(string)*
+    - **`name`** *(string)*
 
-      - **`name`** *(string)*
+    - **`description`** *(string)*
 
-      - **`description`** *(string)*
+    - **`value_type`** *(string)*: Must be one of: `['string', 'number', 'boolean', 'cidr', 'resource']`.
 
-      - **`value_type`** *(string)*: Must be one of: `['string', 'number', 'boolean', 'cidr', 'resource']`.
+    - **`validation`** *(string)*
 
-      - **`validation`** *(string)*
+    - **`required`** *(boolean)*
 
-      - **`required`** *(boolean)*
+    - **`editable`** *(boolean)*
 
-      - **`editable`** *(boolean)*
+    - **`enabled`** *(boolean)*
 
-      - **`enabled`** *(boolean)*
+    - **`default_value`** *(string)*
 
-      - **`default_value`** *(string)*
+    - **`options`** *(array)*
 
-      - **`options`** *(array)*
+      - **Items** *(object)*: Cannot contain additional properties.
 
-        - **Items** *(object)*: Cannot contain additional properties.
+        - **`name`** *(string)*
 
-          - **`name`** *(string)*
+        - **`value`** *(string)*
 
-          - **`value`** *(string)*
+    - **`conditions`** *(array)*
 
-      - **`conditions`** *(array)*
+      - **Items** *(object)*: Cannot contain additional properties.
 
-        - **Items** *(object)*: Cannot contain additional properties.
+        - **`resource`** *(string)*: Must be one of: `['cluster']`.
 
-          - **`resource`** *(string)*: Must be one of: `['cluster']`.
+        - **`data`** *(object)*: Cannot contain additional properties.
 
-          - **`data`** *(object)*: Cannot contain additional properties.
+          - **`aws.sts.enabled`** *(boolean)*
 
-            - **`aws.sts.enabled`** *(boolean)*
+          - **`ccs.enabled`** *(boolean)*
 
-            - **`ccs.enabled`** *(boolean)*
+          - **`cloud_provider.id`** *(['array', 'string'])*
 
-            - **`cloud_provider.id`** *(['array', 'string'])*
+            - **Items** *(string)*
 
-              - **Items** *(string)*
+          - **`product.id`** *(['array', 'string'])*
 
-            - **`product.id`** *(['array', 'string'])*
+            - **Items** *(string)*
 
-              - **Items** *(string)*
-
-            - **`version.raw_id`** *(string)*
+          - **`version.raw_id`** *(string)*
 
 - **`addOnRequirements`** *(array)*
 

--- a/managedtenants/data/imageset.schema.yaml
+++ b/managedtenants/data/imageset.schema.yaml
@@ -15,108 +15,101 @@ properties:
     items:
       type: string
   addOnParameters:
-    type: object
-    description: "List of Addon Parameters"
-    additionalProperties: false
-    required:
-      - items
-    properties:
-      items:
-        type: array
-        items:
-          type: object
-          additionalProperties: false
-          required:
-            - id
-            - name
-            - description
-            - value_type
-            - required
-            - editable
-            - enabled
-          properties:
-            id:
-              type: string
-              format: printable
-            name:
-              type: string
-              format: printable
-            description:
-              type: string
-              format: printable
-            value_type:
-              type: string
-              enum:
-                - string
-                - number
-                - boolean
-                - cidr
-                - resource
-            validation:
-              type: string
-              format: printable
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - description
+        - value_type
+        - required
+        - editable
+        - enabled
+      properties:
+        id:
+          type: string
+          format: printable
+        name:
+          type: string
+          format: printable
+        description:
+          type: string
+          format: printable
+        value_type:
+          type: string
+          enum:
+            - string
+            - number
+            - boolean
+            - cidr
+            - resource
+        validation:
+          type: string
+          format: printable
+        required:
+          type: boolean
+        editable:
+          type: boolean
+        enabled:
+          type: boolean
+        default_value:
+          type: string
+          format: printable
+        options:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
             required:
-              type: boolean
-            editable:
-              type: boolean
-            enabled:
-              type: boolean
-            default_value:
-              type: string
-              format: printable
-            options:
-              type: array
-              items:
+              - name
+              - value
+            properties:
+              name:
+                type: string
+                format: printable
+              value:
+                type: string
+                format: printable
+        conditions:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - resource
+              - data
+            properties:
+              resource:
+                type: string
+                enum:
+                  - cluster
+              data:
                 type: object
                 additionalProperties: false
-                required:
-                  - name
-                  - value
                 properties:
-                  name:
+                  aws.sts.enabled:
+                    type: boolean
+                  ccs.enabled:
+                    type: boolean
+                  cloud_provider.id:
+                    type:
+                      - array
+                      - string
+                    items:
+                      type: string
+                      format: printable
+                  product.id:
+                    type:
+                      - array
+                      - string
+                    items:
+                      type: string
+                      format: printable
+                  version.raw_id:
                     type: string
                     format: printable
-                  value:
-                    type: string
-                    format: printable
-            conditions:
-              type: array
-              items:
-                type: object
-                additionalProperties: false
-                required:
-                  - resource
-                  - data
-                properties:
-                  resource:
-                    type: string
-                    enum:
-                      - cluster
-                  data:
-                    type: object
-                    additionalProperties: false
-                    properties:
-                      aws.sts.enabled:
-                        type: boolean
-                      ccs.enabled:
-                        type: boolean
-                      cloud_provider.id:
-                        type:
-                          - array
-                          - string
-                        items:
-                          type: string
-                          format: printable
-                      product.id:
-                        type:
-                          - array
-                          - string
-                        items:
-                          type: string
-                          format: printable
-                      version.raw_id:
-                        type: string
-                        format: printable
   addOnRequirements:
     type: array
     items:

--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -172,6 +172,13 @@ class OcmCli:
 
         for key, val in imageset.items():
             if key in self.IMAGESET_KEYS:
+                if key == "addOnParameters":
+                    # Enforce a sort order field on addon parameters
+                    # so that they can be shown in the same order as
+                    # the imageset file.
+                    for index, param in enumerate(val):
+                        param["order"] = index
+                    val = {"items": val}
                 addon[self.IMAGESET_KEYS[key]] = val
         return addon
 


### PR DESCRIPTION
Removes the `items` field from `imageset.addOnParameters`, instead, array items can directly be appended to `imageset.addOnParameters`, similar to metadata.addOnParameters.

The OCM upsert function has been modified to append array items to the `items` field instead, to comply with the OCM API Spec.

Tested and verified locally against OCM stage:

```bash
❯ ./venv/bin/managedtenants --environment stage --addons-dir addons --addon-name reference-addon run --debug tasks/deploy/30_ocm_upsert.py
Loading stage...
Loading stage OK
== TASKS =======================================================================
tasks/deploy/30_ocm_upsert.py:OcmUpsert:reference-addon:stage...
OCM upsert for reference-addon
tasks/deploy/30_ocm_upsert.py:OcmUpsert:reference-addon:stage OK
```