### PR TITLE
adding validation_err_msg to addOnParameter schema

### DIFF
--- a/managedtenants/schemas/shared/addon_parameters.json
+++ b/managedtenants/schemas/shared/addon_parameters.json
@@ -39,6 +39,10 @@
         "type": "string",
         "format": "printable"
       },
+      "validation_err_msg": {
+        "type": "string",
+        "format": "printable"
+      },
       "required": {
         "type": "boolean"
       },


### PR DESCRIPTION
When a user enters an invalid value for the add-on parameter, they are returned an error message with the regular expression that the parameter failed to match. This is not a good user experience, especially if the regex is long and complex. 

I've filed an MR ([uhc-clusters-service!3547](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/3547)) to clusters-service that adds a validation_error_message field that AddOn developers can use to return a custom error message should an invalid parameter value be provided.

This PR adds the new field to the metadata schema, so that the cli can pass this data to ocm.