### PR TITLE
dind changes for dockerfile.test

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -4,6 +4,12 @@ FROM registry.access.redhat.com/ubi8/python-39:latest
 ENV CI=true
 USER root
 
+# Install docker-ce for RHEL8
+RUN dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo \
+    && dnf install -y docker-ce \
+    && dnf clean all
+
+
 WORKDIR /managedtenant-cli
 
 COPY . ./

--- a/Makefile
+++ b/Makefile
@@ -86,4 +86,4 @@ docker-build:
 
 CMD := check
 docker-run: docker-build
-	docker run --rm -it --name managedtenants_cli-dev $(DEV_IMAGE) $(CMD)
+	docker run --rm -it --name managedtenants_cli-dev -v "/var/run/docker.sock:/var/run/docker.sock" $(DEV_IMAGE) $(CMD)

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -5,4 +5,11 @@ set -exvo pipefail -o nounset
 IMAGE_TEST=managedtenants-cli
 
 docker build -t ${IMAGE_TEST} -f Dockerfile.test .
-docker run --rm ${IMAGE_TEST} check test
+
+docker_run_args=(
+    --rm
+    -v "/var/run/docker.sock:/var/run/docker.sock"
+)
+
+
+docker run "${docker_run_args[@]}" "${IMAGE_TEST}" check test


### PR DESCRIPTION
Exposes the docker cmd and docker sock to the test container.
Fixes the failing tests in https://github.com/mt-sre/managed-tenants-cli/pull/72.
Signed-off-by: ashish <asnaraya@redhat.com>