### PR TITLE
conditionally ensure quay repo's presence

### DIFF
--- a/managedtenants/bundles/bundle_builder.py
+++ b/managedtenants/bundles/bundle_builder.py
@@ -81,6 +81,7 @@ class BundleBuilder:
         versions,
         hash_string,
         docker_file_path,
+        ensure_quay_repo=True,
     ):
         # pylint: disable=R0913
         """
@@ -102,6 +103,7 @@ class BundleBuilder:
                     versions=versions,
                     hash_string=hash_string,
                     dockerfile_path=docker_file_path,
+                    ensure_quay_repo=ensure_quay_repo,
                 )
             )
         return addon_images
@@ -136,6 +138,7 @@ class BundleBuilder:
         addon,
         hash_string,
         dockerfile_path,
+        ensure_quay_repo,
         versions=None,
     ):
         # pylint: disable=R0913
@@ -169,6 +172,7 @@ class BundleBuilder:
                 hash_string=hash_string,
                 docker_file_path=dockerfile_path,
                 addon_name=addon_name,
+                ensure_quay_repo=ensure_quay_repo,
             )
             images.append(
                 self.validate_bundle_image(
@@ -183,10 +187,13 @@ class BundleBuilder:
         hash_string,
         docker_file_path,
         addon_name,
+        ensure_quay_repo,
     ):
         # pylint: disable=R0913
         repo_name = f"{addon_name}-bundle"
-        if not self.quay_api.ensure_repo(repo_name, dry_run=self.dry_run):
+        if ensure_quay_repo and not self.quay_api.ensure_repo(
+            repo_name, dry_run=self.dry_run
+        ):
             raise BundleBuilderError(
                 f"Failed to create/find quay repo:{repo_name} for the addon:"
                 f" {addon_name}"

--- a/managedtenants/bundles/index_builder.py
+++ b/managedtenants/bundles/index_builder.py
@@ -24,7 +24,9 @@ class IndexBuilder:
         self.docker_conf = docker_conf_path
         self.logger = get_text_logger("managedtenants-catalog-builder")
 
-    def build_push_index_image(self, bundle_images, hash_string):
+    def build_push_index_image(
+        self, bundle_images, hash_string, ensure_quay_repo=True
+    ):
         """
         Returns an index image which points to the passed bundle_images.
         :param hash_string: A string to be used in the created image's tag.
@@ -35,7 +37,9 @@ class IndexBuilder:
         dry_run = self.dry_run
         addon = self.addon_dir
         repo_name = f"{addon.name}-index"
-        if not self.quay_api.ensure_repo(repo_name, dry_run=self.dry_run):
+        if ensure_quay_repo and not self.quay_api.ensure_repo(
+            repo_name, dry_run=self.dry_run
+        ):
             raise IndexBuilderError(
                 f"Failed to create/find quay repo:{repo_name} for the addon:"
                 f" {addon.name}"


### PR DESCRIPTION
This PR introduces a new argument to  `build_push_bundle_images_with_deps` and `build_push_index_image` which determines whether to ensure the passed quay repo's presence or not.

Signed-off-by: ashish <asnaraya@redhat.com>