### PR TITLE
MTSRE-419 | fix bool misinterpretation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: trailing-whitespace
   # Black
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
         args: ["--config", ".linters/black", "--experimental-string-processing"]

--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -24,7 +24,7 @@ _PERMITTED_SUBSCRIPTION_CONFIGS = ["env"]
 
 
 class Addon:
-    def __init__(self, path, environment):
+    def __init__(self, path, environment, override_manager=None):
         self.path = path
         self.extra_resources_loader = None
         self.metadata = self.load_metadata(environment=environment)
@@ -57,6 +57,9 @@ class Addon:
             self.manager = AddonManager.UKNOWN
         else:
             self.manager = AddonManager.ADDON_OPERATOR
+
+        if override_manager is not None:
+            self.manager = override_manager
 
         self.sss = Sss(addon=self)
 

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -99,7 +99,8 @@ items:
           env:
           {% for env_obj in ADDON.get_subscription_config().get("env") %}
           - name: {{env_obj['name']}}
-            value: {{env_obj['value']}}
+            value: |-
+              {{env_obj['value']}}
           {% endfor %}
         {% endif %}
 
@@ -185,7 +186,8 @@ items:
               env:
               {% for env_obj in ADDON.get_subscription_config().get("env") %}
               - name: {{env_obj['name']}}
-                value: {{env_obj['value']}}
+                value: |-
+                  {{env_obj['value']}}
               {% endfor %}
             {% endif %}
 {% endif %}

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -146,6 +146,7 @@ def test_raises_imageset_missing_error():
             [
                 {"name": "LOCATION", "value": "Black Mesa Research Facility"},
                 {"name": "USER", "value": "Gordon Freeman"},
+                {"name": "HUMAN", "value": "true"},
             ],
         ),
         ("addon_with_imageset_and_no_config", None),
@@ -154,6 +155,7 @@ def test_raises_imageset_missing_error():
             [
                 {"name": "LOCATION", "value": "Black Mesa Research Facility"},
                 {"name": "USER", "value": "Gordon Freeman"},
+                {"name": "HUMAN", "value": "true"},
             ],
         ),
         (
@@ -161,6 +163,7 @@ def test_raises_imageset_missing_error():
             [
                 {"name": "LOCATION", "value": "Black Mesa Research Facility"},
                 {"name": "USER", "value": "Gordon Freeman"},
+                {"name": "HUMAN", "value": "true"},
             ],
         ),
     ],

--- a/tests/sss/test_federated_metrics.py
+++ b/tests/sss/test_federated_metrics.py
@@ -43,7 +43,7 @@ def test_namespace_and_servicemonitor_v1(data):
     )
 
     for matchName in addon.metadata["monitoring"]["matchNames"]:
-        series_name = f"""'{{__name__="{matchName}"}}'"""
+        series_name = f"""{{__name__="{matchName}"}}"""
         assert series_name in sm["spec"]["endpoints"][0]["params"]["match[]"]
 
     for k, v in addon.metadata["monitoring"]["matchLabels"].items():

--- a/tests/sss/test_subscription_config.py
+++ b/tests/sss/test_subscription_config.py
@@ -19,6 +19,7 @@ def test_subscription_config(addon_str, request):
     expected_values = [
         {"name": "LOCATION", "value": "Black Mesa Research Facility"},
         {"name": "USER", "value": "Gordon Freeman"},
+        {"name": "HUMAN", "value": "true"},
     ]
 
     if addon_str == "addons_managed_by_addon_cr":
@@ -46,7 +47,7 @@ def test_subscription_config(addon_str, request):
         ][0]
         if addon.get_subscription_config():
             _, subscription_contents = subscription_obj
-            assert len(subscription_contents["spec"]["config"]["env"]) == 2
+            assert len(subscription_contents["spec"]["config"]["env"]) == 3
             for env_obj in subscription_contents["spec"]["config"]["env"]:
                 assert env_obj in expected_values
         else:

--- a/tests/testdata/addons/mock-operator-with-imagesets/addonimagesets/stage/mock-operator.v1.0.0.yml
+++ b/tests/testdata/addons/mock-operator-with-imagesets/addonimagesets/stage/mock-operator.v1.0.0.yml
@@ -10,3 +10,5 @@ subscriptionConfig:
     value: Black Mesa Research Facility
   - name: USER
     value: Gordon Freeman
+  - name: HUMAN
+    value: 'true'

--- a/tests/testdata/addons/test-operator/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/test-operator/metadata/stage/addon.yaml
@@ -34,3 +34,5 @@ subscriptionConfig:
     value: Black Mesa Research Facility
   - name: USER
     value: Gordon Freeman
+  - name: HUMAN
+    value: 'true'

--- a/tests/testutils/addon_helpers.py
+++ b/tests/testutils/addon_helpers.py
@@ -69,10 +69,9 @@ def addon_with_indeximage():
 @pytest.fixture
 def addons_managed_by_addon_cr():
     def create_addon_managed_by_addon_cr(path):
-        addon = Addon(path, "stage")
-        addon.manager = AddonManager.ADDON_OPERATOR
-        addon.sss = Sss(addon=addon)
-        return addon
+        return Addon(
+            path, "stage", override_manager=AddonManager.ADDON_OPERATOR
+        )
 
     addon_paths = [addon_with_imageset_path(), addon_with_indeximage_path()]
     return list(map(create_addon_managed_by_addon_cr, addon_paths))


### PR DESCRIPTION
the YAMLloader renders values in the jinja template without quotes. Now that perfectly works for generic strings but messes up when the value is something which can be interpreted as a non-string type like, true/false, any int like 2, 42, etc. 

But we want to deterministically ensure that under subscriptionConfig, the value, even if provided with "true", "false", "1", "2", etc. ends up explicitly getting interpreted as a string and the block chomping indicator `|-` in this PR accomplishes that

Example:

**Before this PR**

**_Regular succeeding situations_**

_Input_
```json
{"env": {"name": "healthy", "value": "yes"}}
```
_Intermediate Representation_
```yaml
env:
  name: healthy ### parsed by YAML as a string
  value: yes ### parsed by YAML as a string
```
_Dumped YAML Output_
```yaml
env:
  name: healthy
  value: yes
```

**_Failing situations_**

_Input_
```json
{"env": {"name": "healthy", "value": "true"}}
```
_Intermediate Representation_
```yaml
env:
  name: healthy ### parsed by YAML as a string
  value: true ### parsed by YAML as a bool despite being inputted with a stringified "true"
```
_Dumped YAML Output_
```yaml
env:
  name: healthy
  value: true ## bool
```

**After this PR**

_Input_
```json
{"env": {"name": "healthy", "value": "true"}}
```
_Intermediate Representation_
```yaml
env:
  name: healthy ### parsed by YAML as a string
  value: |-
    true ### parsed by YAML as a string
```
_Dumped YAML Output_
```yaml
env:
  name: healthy
  value: 'true' ## string
```
