### PR TITLE
OCM: Add attributes necessary for STS addons

### DIFF
--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -43,6 +43,12 @@
 
   - **Items** *(string)*
 
+- **`serviceAccount`** *(string)*: Name of the service account created by the addon operator to authenticate to the API.
+
+- **`policyPermissions`** *(array)*: List of permissions in an IAM policy that are required by the addon operator.
+
+  - **Items** *(string)*
+
 - **`pullSecret`** *(string)*
 
 - **`namespaceLabels`** *(object)*: Labels to be applied on all listed namespaces.

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -69,6 +69,16 @@ properties:
       type: string
       pattern: ^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$
     description: "Namespaces managed by the addon-operator. Need to include the TargetNamespace."
+  serviceAccount:
+    type: string
+    pattern: ^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$
+    description: "Name of the service account created by the addon operator to authenticate to the API."
+  policyPermissions:
+    type: array
+    description: "List of permissions in an IAM policy that are required by the addon operator."
+    items:
+      type: string
+      pattern: ^[a-z0-9]{1,60}:[A-Za-z0-9]{1,60}$
   pullSecret:
     type: string
     format: printable

--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -45,6 +45,8 @@ class OcmCli:
         "ocmQuotaCost": "resource_cost",
         "operatorName": "operator_name",
         "hasExternalResources": "has_external_resources",
+        "serviceAccount": "service_account",
+        "policyPermissions": "policy_permissions",
         "addOnParameters": "parameters",
         "addOnRequirements": "requirements",
         "subOperators": "sub_operators",


### PR DESCRIPTION
When installing an addon that needs access to AWS resources on an STS
cluster, the addon needs to announce which service account to use for
generating the token and the list of policy permissions required.

This will allow ROSA to guide the user through the role/policy creation
process, and allow OCM to validate that the authentication works when
the user supplies the resulting IAM role ARN.

* https://issues.redhat.com/browse/SDA-5367
* https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/3783
* https://github.com/openshift-online/ocm-api-model/pull/484