### PR TITLE
Adding pattern to ImageSet name

### DIFF
--- a/managedtenants/schemas/imageset.schema.yaml
+++ b/managedtenants/schemas/imageset.schema.yaml
@@ -5,6 +5,7 @@ additionalProperties: false
 properties:
   name:
     type: string
+    pattern: ^[a-z-]+.v[0-9A-Za-z\.-]+$
     description: "The name of the imageset along with the version"
   indexImage:
     type: string


### PR DESCRIPTION
The pattern we follow should allow for:

```
<addon-id>.v<semantic-version>
```

Examples:
rhoams.v1.16.0
managed-odh.v2.0.1-pre1

This patch adds a regex to minimally validate the expected pattern.

Related to CPAAS-3281