### PR TITLE
Ensuring `pytest <7.0.0` when running tests in CI

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pytest = "6.2.4"
+pytest = "<7.0.0"
 mock = "4.0.3"
 hypothesis = "6.14.2"
 hypothesis_jsonschema = "0.20.1"


### PR DESCRIPTION
### Summary

CI pr_check runs have been failing since `pytest 7.0.0` was released. The `Pipfile` should pin the version, but is a patch version behind which could be preventing proper installation. This change will just enforce that `pytest` is at the latest `6.X.X` version.

See [here](https://github.com/pytest-dev/pytest/issues/9608) for background on why `pytest 7.0.0` is incompatible with `Python 3.9.6`.