### PR TITLE
[MTSRE-453] Allow only `latest` for addonImageSetVersion

### DIFF
--- a/managedtenants/core/addons_loader/__init__.py
+++ b/managedtenants/core/addons_loader/__init__.py
@@ -3,7 +3,8 @@ from managedtenants.utils.git import ChangeDetector
 
 
 def instantiate_addon(args):
-    return Addon(path=args[0], environment=args[1])
+    # TODO: Remove `imageset_latest_only` arg
+    return Addon(path=args[0], environment=args[1], imageset_latest_only=True)
 
 
 def load_addons(path, environment, addon_name, args):


### PR DESCRIPTION
Signed-off-by: Mayank Shah <m.shah@redhat.com>

# py-mtcli

## Description

Short description of the change:

Modifed Addon loader to error out when `addonImageSetVersion` is set to anything apart from `"latest"`. See https://issues.redhat.com/browse/MTSRE-453
## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
