### PR TITLE
adding managedService flag to indicate if an addon is a managed service

### DIFF
--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -160,3 +160,5 @@
 - **`subOperators`**: Refer to *shared/sub_operators.json*.
 
 - **`subscriptionConfig`**: Refer to *shared/subscription_config.json*.
+
+- **`managedService`** *(boolean)*: Indicates if the add-on will be used as a Managed Service.

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -284,6 +284,9 @@ properties:
     $ref: "shared/sub_operators.json"
   subscriptionConfig:
     $ref: "shared/subscription_config.json"
+  managedService:
+    type: boolean
+    description: "Indicates if the add-on will be used as a Managed Service."
 required:
   - id
   - name

--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -46,6 +46,7 @@ class OcmCli:
         "addOnParameters": "parameters",
         "addOnRequirements": "requirements",
         "subOperators": "sub_operators",
+        "managedService" : "managed_service",
     }
 
     IMAGESET_KEYS = {


### PR DESCRIPTION
https://issues.redhat.com/browse/SDA-5359
# py-mtcli

## Description

Short description of the change:

- A managedService field was added to the addons schema, which will be used to determine if the add-on is a managed service. 

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
