### PR TITLE
[MTSRE-472] Extending `operatorName` valid length

### DIFF
--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -154,7 +154,7 @@ properties:
     minimum: 0
   operatorName:
     type: string
-    pattern: ^[A-Za-z0-9][A-Za-z0-9-]{0,30}[A-Za-z0-9]$
+    pattern: ^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$
     description: "Name of the addon operator."
   bundleParameters:
     type: object


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- Updated metadata schema to permit `operatorname` longer than 32 characters.
 