### PR TITLE
Changing the pullSecret Secret name

### DIFF
--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -39,7 +39,7 @@ items:
     - apiVersion: v1
       kind: Secret
       metadata:
-        name: addon-{{ADDON.metadata['id']}}-pullsecret
+        name: addon-pullsecret
         namespace: {{namespace}}
         {{ maybe_annotations(ADDON.metadata.get('commonAnnotations')) | indent(8) }}
         {{


### PR DESCRIPTION
# py-mtcli

## Description

The Secret needs a deterministic name, but not need to make it related to the addon itself, as we creat it in the namespace of the addon anyway.

This will make it easier to find the secret, regardless the operator looking for it.

## Checklist

**For any modification to `managedtenants/bundles/`**

- [x] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [x] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
