### PR TITLE
Fix keyword in parameter type <resource_requirement>

### DIFF
--- a/managedtenants/schemas/shared/addon_parameters.json
+++ b/managedtenants/schemas/shared/addon_parameters.json
@@ -75,7 +75,7 @@
               "type": "string",
               "format": "printable"
             },
-            "addOnRequirements":{
+            "requirements":{
               "$ref": "addon_requirements.json"
             }
           }

--- a/tests/testdata/addons/mock-operator-with-imagesets/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-imagesets/metadata/stage/addon.yaml
@@ -46,7 +46,7 @@ addOnParameters:
     options:
       - name: 1 TiB
         value: "1"
-        addOnRequirements:
+        requirements:
           - id: managed_svc_machine_pool_req
             resource: machine_pool
             data:


### PR DESCRIPTION
Fixes: JIRA - [SDA-5638](https://issues.redhat.com/browse/SDA-5638)

The keyword used in the "Model" for specifying requirements inside `resource_requirement` parameters is `requirements` not `addOnRequirements`

Signed-off-by: Juan Miguel Olmo Martínez jolmomar@redhat.com
