### PR TITLE
[MTSRE-485] Add a new `additionalCatalogSources` attribute in the addon metadata file

### DIFF
--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -51,6 +51,14 @@
 
 - **`pullSecret`** *(string)*
 
+- **`additionalCatalogSources`** *(array)*: List of additional catalog sources to be created.
+
+  - **Items** *(object)*: Cannot contain additional properties.
+
+    - **`name`** *(string)*: Name of the additional catalog source.
+
+    - **`image`** *(string)*: Url of the additional catalog source image.
+
 - **`namespaceLabels`** *(object)*: Labels to be applied on all listed namespaces.
 
   - **Items** *(string)*

--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -122,11 +122,18 @@ class Addon:
 
         self._validate_schema_instance(metadata, "metadata")
         self._validate_extra_resources(environment, metadata)
+        self._validate_additional_catalogue_srcs(metadata)
 
         if "extraResources" in metadata:
             self.extra_resources_loader = FileSystemLoader(str(metadata_dir))
 
         return metadata
+
+    def _validate_additional_catalogue_srcs(self, metadata):
+        if metadata.get("additionalCatalogSources"):
+            ctlg_src_names = [obj["name"] for obj in metadata["additionalCatalogSources"]]
+            if len(set(ctlg_src_names)) != len(ctlg_src_names):
+                raise AddonLoadError("Additional catalog source should have a unique name")
 
     def load_imageset(self, imageset_version):
         if not version_parsable(imageset_version):

--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -131,9 +131,14 @@ class Addon:
 
     def _validate_additional_catalogue_srcs(self, metadata):
         if metadata.get("additionalCatalogSources"):
-            ctlg_src_names = [obj["name"] for obj in metadata["additionalCatalogSources"]]
+            ctlg_src_names = [
+                obj["name"] for obj in metadata["additionalCatalogSources"]
+            ]
             if len(set(ctlg_src_names)) != len(ctlg_src_names):
-                raise AddonLoadError("Additional catalog source should have a unique name")
+                raise AddonLoadError(
+                    f"{self.path} validation error: Additional catalog source"
+                    " should have a unique name"
+                )
 
     def load_imageset(self, imageset_version):
         if not version_parsable(imageset_version):

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -68,6 +68,24 @@ items:
         publisher: OSD Red Hat Addons
         sourceType: grpc
 
+{% if ADDON.metadata['additionalCatalogSources'] is defined %}
+{% for catalog_src in ADDON.metadata['additionalCatalogSources'] %}
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: CatalogSource
+      metadata:
+        name: {{catalog_src["name"]}}
+        namespace: {{ADDON.metadata["targetNamespace"]}}
+        {{ maybe_annotations(ADDON.metadata.get('commonAnnotations')) | indent(8) }}
+        {{ maybe_labels(ADDON.metadata.get('commonLabels')) | indent(8) }}
+      spec:
+        displayName: >-
+          {{ADDON.metadata['name']}}
+        image: {{catalog_src["image"]}}
+        publisher: OSD Red Hat Addons
+        sourceType: grpc
+{% endfor %}
+{% endif %}
+
 {% if ADDON.metadata['namespaces'] %}
     - apiVersion: operators.coreos.com/v1alpha2
       kind: OperatorGroup

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -82,6 +82,24 @@ properties:
   pullSecret:
     type: string
     format: printable
+  additionalCatalogSources:
+    type: array
+    description: "List of additional catalog sources to be created"
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          format: printable
+          description: "Name of the additional catalog source"
+        image:
+          type: string
+          pattern: ^quay\.io/[0-9A-Za-z._-]+/[a-z-]+
+          description: "Url of the additional catalog source image"
+      required:
+      - name
+      - image
   namespaceLabels:
     type: object
     items:

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -4,7 +4,7 @@ from sretoolbox.container import Image
 
 from managedtenants.core.addons_loader.addon import Addon
 from managedtenants.core.addons_loader.exceptions import AddonLoadError
-from tests.testutils.addon_helpers import addon_with_bundles  # noqa: F401
+from tests.testutils.addon_helpers import addon_with_bundles, addon_with_indeximage_path  # noqa: F401
 from tests.testutils.addon_helpers import addon_with_imageset  # noqa: F401
 from tests.testutils.addon_helpers import addon_with_indeximage  # noqa: F401
 from tests.testutils.addon_helpers import (  # noqa: F401; flake8: noqa: F401
@@ -84,6 +84,13 @@ def test_addon_catalog_image(addon, addon_type, request):
     addon = request.getfixturevalue(addon)
     assert isinstance(addon.catalog_image, Image)
 
+def test_additional_catalogue_src_name_validation():
+    addon = Addon(addon_with_indeximage_path(), "integration")
+    metadata = addon.metadata
+    duplicate = metadata["additionalCatalogSources"][0]
+    metadata["additionalCatalogSources"].append(duplicate)
+    with pytest.raises(AddonLoadError):
+        addon._validate_additional_catalogue_srcs(metadata)
 
 def assert_exceptions_on_addon_initialization(imageset_version, error_to_raise):
     required_metadata = addon_metadata_with_imageset_version(imageset_version)

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -4,18 +4,19 @@ from sretoolbox.container import Image
 
 from managedtenants.core.addons_loader.addon import Addon
 from managedtenants.core.addons_loader.exceptions import AddonLoadError
-from tests.testutils.addon_helpers import addon_with_bundles, addon_with_indeximage_path  # noqa: F401
 from tests.testutils.addon_helpers import addon_with_imageset  # noqa: F401
 from tests.testutils.addon_helpers import addon_with_indeximage  # noqa: F401
-from tests.testutils.addon_helpers import (  # noqa: F401; flake8: noqa: F401
+from tests.testutils.addon_helpers import (  # noqa: F401; noqa: F401; flake8: noqa: F401
     ADDON_WITH_BUNDLES_TYPE,
     ADDON_WITH_IMAGESET_TYPE,
     ADDON_WITH_INDEXIMAGE_TYPE,
     addon_metadata_with_imageset_version,
+    addon_with_bundles,
     addon_with_imageset_and_default_config,
     addon_with_imageset_and_multiple_config,
     addon_with_imageset_and_no_config,
     addon_with_imageset_path,
+    addon_with_indeximage_path,
     addon_with_only_imageset_config,
     load_yaml,
     setup_addon_class_with_stubbed_metadata,
@@ -84,6 +85,7 @@ def test_addon_catalog_image(addon, addon_type, request):
     addon = request.getfixturevalue(addon)
     assert isinstance(addon.catalog_image, Image)
 
+
 def test_additional_catalogue_src_name_validation():
     addon = Addon(addon_with_indeximage_path(), "integration")
     metadata = addon.metadata
@@ -91,6 +93,7 @@ def test_additional_catalogue_src_name_validation():
     metadata["additionalCatalogSources"].append(duplicate)
     with pytest.raises(AddonLoadError):
         addon._validate_additional_catalogue_srcs(metadata)
+
 
 def assert_exceptions_on_addon_initialization(imageset_version, error_to_raise):
     required_metadata = addon_metadata_with_imageset_version(imageset_version)

--- a/tests/sss/test_catalogue_source.py
+++ b/tests/sss/test_catalogue_source.py
@@ -1,7 +1,8 @@
 import pytest
 
+from managedtenants.core.addons_loader.addon import Addon
 from tests.testutils.addon_helpers import addon_with_imageset  # noqa: F401
-from tests.testutils.addon_helpers import addon_with_indeximage  # noqa: F401
+from tests.testutils.addon_helpers import addon_with_indeximage, addon_with_indeximage_path  # noqa: F401
 from tests.testutils.addon_helpers import (  # noqa: F401
     addon_with_deadmanssnitch,
     addon_with_pagerduty,
@@ -45,6 +46,19 @@ def test_addon_sss_object(addon_str, request):
         ]
         assert len(catalogue_src_obj) == 1
         name, data = catalogue_src_obj[0]
+        assert name is not None
+        assert data is not None
+        assert data["spec"]["image"] is not None
+        
+def test_additional_catalog_srcs():
+    addon = Addon(addon_with_indeximage_path(), "integration")
+    sss_walker = addon.sss.walker()
+    catalogue_src_objs = sss_walker["sss_deploy"]["spec"]["resources"][
+        "CatalogSource"
+    ]
+    assert len(catalogue_src_objs) == 2
+    for catalog_obj in catalogue_src_objs:
+        name, data = catalog_obj
         assert name is not None
         assert data is not None
         assert data["spec"]["image"] is not None

--- a/tests/sss/test_catalogue_source.py
+++ b/tests/sss/test_catalogue_source.py
@@ -2,9 +2,10 @@ import pytest
 
 from managedtenants.core.addons_loader.addon import Addon
 from tests.testutils.addon_helpers import addon_with_imageset  # noqa: F401
-from tests.testutils.addon_helpers import addon_with_indeximage, addon_with_indeximage_path  # noqa: F401
 from tests.testutils.addon_helpers import (  # noqa: F401
     addon_with_deadmanssnitch,
+    addon_with_indeximage,
+    addon_with_indeximage_path,
     addon_with_pagerduty,
     addons_managed_by_addon_cr,
 )
@@ -49,7 +50,8 @@ def test_addon_sss_object(addon_str, request):
         assert name is not None
         assert data is not None
         assert data["spec"]["image"] is not None
-        
+
+
 def test_additional_catalog_srcs():
     addon = Addon(addon_with_indeximage_path(), "integration")
     sss_walker = addon.sss.walker()

--- a/tests/testdata/addons/test-operator/metadata/integration/addon.yaml
+++ b/tests/testdata/addons/test-operator/metadata/integration/addon.yaml
@@ -17,5 +17,8 @@ ocmQuotaCost: 1
 operatorName: test-operator
 defaultChannel: alpha
 namespaceLabels: {}
+additionalCatalogSources:
+  - name: new-catalog
+    image: quay.io/osd-addons/test-operator-index@sha256:12ce3270c72134273440c477653b568980b407722366080af758b138f43861891
 namespaceAnnotations: {}
 indexImage: quay.io/osd-addons/test-operator-index@sha256:8980b407722366080af758b138f438618912ce3270c72134273440c477653b56


### PR DESCRIPTION
# py-mtcli

## Description
This PR adds a new attribute (`additionalCatalogSources`) in the addon metadata file.
Jira: https://issues.redhat.com/browse/MTSRE-485


