### PR TITLE
Stop creating Addon CR in the SelectorSyncSet

### DIFF
--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -19,7 +19,7 @@ from managedtenants.utils.schema import load_schema
 # IDs of addons that are managed by the addon-operator
 # These addon IDs _MUST_ be stable and not changed or bad things will happen
 # (this applies to addon IDs in general, but it's worth pointing out here, too)
-_ADDON_OPERATOR_ADDON_IDS = ["reference-addon"]
+_ADDON_OPERATOR_ADDON_IDS = []
 _PERMITTED_SUBSCRIPTION_CONFIGS = ["env"]
 
 


### PR DESCRIPTION
We implemented this functionality for test only, now we need the
SelectorSyncSet to be the regular one and do the proper migration.

## Checklist

**For any modification to `managedtenants/bundles/`**

- [x] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [x] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
