### PR TITLE
[MTSRE-481] Added `secrets` and `pullSecretName` validation

### DIFF
--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -123,6 +123,8 @@ class Addon:
         self._validate_schema_instance(metadata, "metadata")
         self._validate_extra_resources(environment, metadata)
         self._validate_additional_catalogue_srcs(metadata)
+        self._validate_secret_names(metadata)
+        self._validate_pullSecretName(metadata)
 
         if "extraResources" in metadata:
             self.extra_resources_loader = FileSystemLoader(str(metadata_dir))
@@ -138,6 +140,30 @@ class Addon:
                 raise AddonLoadError(
                     f"{self.path} validation error: Additional catalog source"
                     " should have a unique name"
+                )
+
+    def _validate_secret_names(self, metadata):
+        if metadata.get("secrets"):
+            secret_names = [
+                secret["name"] for secret in metadata["secrets"]
+            ]
+            if len(set(secret_names)) != len(secret_names):
+                raise AddonLoadError(
+                    f"{self.path} validation error: secrets should have a unique name"
+                )
+
+    def _validate_pullSecretName(self,metadata):
+        if metadata.get("pullSecretName"):
+            if not metadata.get("secrets"):
+                raise AddonLoadError(
+                    f"{self.path} validation error: No secrets provided,"
+                    " pullSecretName should be one of secrets' names"
+                )
+            secret_names = [secret["name"] for secret in metadata["secrets"]]
+            if not metadata["pullSecretName"] in secret_names:
+                raise AddonLoadError(
+                    f"{self.path} validation error: pullSecretName should"
+                    " be one of secrets' names"
                 )
 
     def load_imageset(self, imageset_version):

--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -144,15 +144,14 @@ class Addon:
 
     def _validate_secret_names(self, metadata):
         if metadata.get("secrets"):
-            secret_names = [
-                secret["name"] for secret in metadata["secrets"]
-            ]
+            secret_names = [secret["name"] for secret in metadata["secrets"]]
             if len(set(secret_names)) != len(secret_names):
                 raise AddonLoadError(
-                    f"{self.path} validation error: secrets should have a unique name"
+                    f"{self.path} validation error: secrets"
+                    " should have a unique name"
                 )
 
-    def _validate_pullSecretName(self,metadata):
+    def _validate_pullSecretName(self, metadata):
         if metadata.get("pullSecretName"):
             if not metadata.get("secrets"):
                 raise AddonLoadError(

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -19,6 +19,7 @@ from tests.testutils.addon_helpers import (  # noqa: F401; noqa: F401; flake8: n
     addon_with_imageset_path,
     addon_with_indeximage_path,
     addon_with_only_imageset_config,
+    addon_with_secrets_path,
     load_yaml,
     setup_addon_class_with_stubbed_metadata,
 )
@@ -95,6 +96,27 @@ def test_additional_catalogue_src_name_validation():
     metadata["additionalCatalogSources"].append(duplicate)
     with pytest.raises(AddonLoadError):
         addon._validate_additional_catalogue_srcs(metadata)
+
+
+def test_secret_names_validation():
+    addon = Addon(addon_with_secrets_path(), "stage")
+    metadata = addon.metadata
+    duplicate = metadata["secrets"][0]
+    metadata["secrets"].append(duplicate)
+    with pytest.raises(AddonLoadError):
+        addon._validate_secret_names(metadata)
+
+
+def test_pullSecretName_validation():
+    addon = Addon(addon_with_secrets_path(), "stage")
+    metadata = addon.metadata
+    pullSecretName = metadata["pullSecretName"]
+    secrets = metadata["secrets"]
+    metadata["secrets"] = list(
+        filter(lambda secret: secret["name"] != pullSecretName, secrets)
+    )
+    with pytest.raises(AddonLoadError):
+        addon._validate_pullSecretName(metadata)
 
 
 def assert_exceptions_on_addon_initialization(imageset_version, error_to_raise):

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -110,11 +110,8 @@ def test_secret_names_validation():
 def test_pullSecretName_validation():
     addon = Addon(addon_with_secrets_path(), "stage")
     metadata = addon.metadata
-    pullSecretName = metadata["pullSecretName"]
-    secrets = metadata["secrets"]
-    metadata["secrets"] = list(
-        filter(lambda secret: secret["name"] != pullSecretName, secrets)
-    )
+    """Assigning a random UUID"""
+    metadata["pullSecretName"] = "5daad7e9-dea7-4b3a-9fe5-a773df8ec57c"
     with pytest.raises(AddonLoadError):
         addon._validate_pullSecretName(metadata)
 


### PR DESCRIPTION
# py-mtcli

## Description

Added the following validation checks:

- `secret` names should be unique
- `pullSecretName` should be one of `secrets`'s names
