### PR TITLE
add regex validation for addon environment variable name attribute

### DIFF
--- a/managedtenants/schemas/shared/subscription_config.json
+++ b/managedtenants/schemas/shared/subscription_config.json
@@ -19,7 +19,7 @@
         "properties": {
           "name": {
             "type": "string",
-            "format": "printable"
+            "pattern": "^[A-Z][A-Z0-9_]*$"
           },
           "value": {
             "type": "string",


### PR DESCRIPTION
Adds regex validation for addon environment variable name attribute. We need this validation since environment variable names should consist solely of uppercase letters, digits, and ‘_’ and do not begin with a digit.
Signed-off-by: ashish <asnaraya@redhat.com>
