### PR TITLE
conditionally inject secrets to the created catalog src objects

### DIFF
--- a/managedtenants/bundles/addon_bundles.py
+++ b/managedtenants/bundles/addon_bundles.py
@@ -140,7 +140,7 @@ class AddonBundles:
         except jsonschema.exceptions.ValidationError as e:
             raise AddonBundlesError(f"schema validation error for {self}: {e}")
 
-    @lru_cache(maxsize=None)
+    @lru_cache()
     def _get_latest_version(self):
         """
         Returns the latest version amongst the main_bundles.

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -67,6 +67,10 @@ items:
         image: {{ADDON.image_tag.format(hash='${IMAGE_TAG}')}}
         publisher: OSD Red Hat Addons
         sourceType: grpc
+        {% if ADDON.metadata['pullSecretName'] is defined %}
+        secrets:
+          - {{ADDON.metadata['pullSecretName']}}
+        {% endif %}
 
 {% if ADDON.metadata['additionalCatalogSources'] is defined %}
 {% for catalog_src in ADDON.metadata['additionalCatalogSources'] %}
@@ -83,6 +87,10 @@ items:
         image: {{catalog_src["image"]}}
         publisher: OSD Red Hat Addons
         sourceType: grpc
+        {% if ADDON.metadata['pullSecretName'] is defined %}
+        secrets:
+          - {{ADDON.metadata['pullSecretName']}}
+        {% endif %}
 {% endfor %}
 {% endif %}
 

--- a/tests/testdata/addons/mock-operator-with-secrets/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-secrets/metadata/stage/addon.yaml
@@ -33,3 +33,6 @@ secrets:
     type: kubernetes.io/dockerconfigjson
     vaultPath: mtsre/quay/osd-addons/secrets/mocksecret/mock-operator-secret-2
 pullSecretName: mock-operator-pull-secret-2
+additionalCatalogSources:
+  - name: new-catalog
+    image: quay.io/osd-addons/test-operator-index@sha256:12ce3270c72134273440c477653b568980b407722366080af758b138f43861891


### PR DESCRIPTION
Fixes: [MTSRE-497](https://issues.redhat.com/browse/MTSRE-497)
Signed-off-by: ashish <asnaraya@redhat.com>


## Description
This PR modifies the SSS jinja template to use the `pullSecretName` attribute as a `secret` parameter in the created catalog source objects.
