### PR TITLE
[MTSRE-500] Adding packageName to the addon metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,13 +24,13 @@ repos:
   #
   # Built-ins
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   # Black
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: ["--config", ".linters/black", "--experimental-string-processing"]

--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -107,6 +107,8 @@
 
 - **`operatorName`** *(string)*: Name of the addon operator.
 
+- **`packageName`** *(string)*: Name of the addon OLM package. Defaults to operatorName when not specified.
+
 - **`bundleParameters`** *(object)*: Cannot contain additional properties.
 
   - **`useClusterStorage`** *(string)*

--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -139,6 +139,9 @@ class Addon:
         if "extraResources" in metadata:
             self.extra_resources_loader = FileSystemLoader(str(metadata_dir))
 
+        if "packageName" not in metadata:
+            metadata["packageName"] = metadata["operatorName"]
+
         return metadata
 
     def _validate_additional_catalogue_srcs(self, metadata):

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -210,6 +210,10 @@ properties:
     type: string
     pattern: ^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$
     description: "Name of the addon operator."
+  packageName:
+    type: string
+    pattern: ^[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9]$
+    description: "Name of the addon OLM package. Defaults to operatorName when not specified."
   bundleParameters:
     type: object
     additionalProperties: false

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -20,6 +20,8 @@ from tests.testutils.addon_helpers import (  # noqa: F401; noqa: F401; flake8: n
     addon_with_indeximage_path,
     addon_with_only_imageset_config,
     addon_with_secrets_path,
+    addon_without_package_name_path,
+    addon_with_package_name_path,
     load_yaml,
     setup_addon_class_with_stubbed_metadata,
 )
@@ -228,3 +230,10 @@ def test_addon_subscription_config_validations(addon, addon_type, request):
         updated_imageset["subscriptionConfig"]["unsupportedAttr"] = "present"
         with pytest.raises(AddonLoadError):
             addon._validate_schema_instance(updated_imageset, "imageset")
+
+
+def test_package_name():
+    addon = Addon(addon_without_package_name_path(), "stage")
+    assert addon.metadata["packageName"] == addon.metadata["operatorName"]
+    addon = Addon(addon_with_package_name_path(), "production")
+    assert addon.metadata["packageName"] != addon.metadata["operatorName"]

--- a/tests/testdata/addons/mock-operator-with-bundles/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-bundles/metadata/stage/addon.yaml
@@ -18,6 +18,7 @@ ocmQuotaName: addon-mock-operator
 ocmQuotaCost: 1
 testHarness: quay.io/mock-operator/mock-operator-test-harness
 operatorName: mock-operator
+packageName: mock-operator
 hasExternalResources: true
 channels:
 - name: alpha

--- a/tests/testdata/addons/mock-operator-with-imagesets/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-imagesets/metadata/stage/addon.yaml
@@ -18,6 +18,7 @@ ocmQuotaName: addon-mock-operator
 ocmQuotaCost: 1
 testHarness: quay.io/mock-operator/mock-operator-test-harness
 operatorName: mock-operator
+packageName: mock-operator
 hasExternalResources: true
 channels:
 - name: alpha

--- a/tests/testdata/addons/mock-operator-with-secrets/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-secrets/metadata/stage/addon.yaml
@@ -18,6 +18,7 @@ ocmQuotaName: addon-mock-operator
 ocmQuotaCost: 1
 testHarness: quay.io/mock-operator/mock-operator-test-harness
 operatorName: mock-operator-secrets
+packageName: mock-operator-secrets
 hasExternalResources: true
 channels:
 - name: alpha

--- a/tests/testdata/addons/test-operator/metadata/production/addon.yaml
+++ b/tests/testdata/addons/test-operator/metadata/production/addon.yaml
@@ -19,3 +19,4 @@ defaultChannel: alpha
 namespaceLabels: {}
 namespaceAnnotations: {}
 indexImage: quay.io/osd-addons/test-operator-index@sha256:8980b407722366080af758b138f438618912ce3270c72134273440c477653b56
+packageName: test-operator-package

--- a/tests/testutils/addon_helpers.py
+++ b/tests/testutils/addon_helpers.py
@@ -40,6 +40,14 @@ def addon_with_secrets_path():
     return Path("tests/testdata/addons/mock-operator-with-secrets")
 
 
+def addon_without_package_name_path():
+    return Path("tests/testdata/addons/test-operator")
+
+
+def addon_with_package_name_path():
+    return Path("tests/testdata/addons/test-operator")
+
+
 @pytest.fixture
 def mt_bundles_with_invalid_dir_structure_path():
     return Path("tests/testdata/addons/mock-operator-with-bundles")


### PR DESCRIPTION

# py-mtcli

## Description

The packageName, when not defined, defaults to the operatorName.

## Checklist

**For any modification to `managedtenants/bundles/`**

- [x] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [x] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
