### PR TITLE
[SDA-5777] Pass the packageName to OCM

### DIFF
--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -40,6 +40,7 @@ class OcmCli:
         "ocmQuotaName": "resource_name",
         "ocmQuotaCost": "resource_cost",
         "operatorName": "operator_name",
+        "packageName": "package_name",
         "hasExternalResources": "has_external_resources",
         "serviceAccount": "service_account",
         "policyPermissions": "policy_permissions",


### PR DESCRIPTION
Depends on the OCM counterpart of SDA-5777 