### PR TITLE
LazyBin fix, pull binaries only when they are ran.

### DIFF
--- a/managedtenants/bundles/binary_deps.py
+++ b/managedtenants/bundles/binary_deps.py
@@ -1,5 +1,25 @@
 from sretoolbox.binaries import Mtcli, OperatorSDK, Opm
 
-OPM = Opm(version="1.19.5", download_path="/tmp")
-MTCLI = Mtcli(version="0.10.0", download_path="/tmp")
-OPERATOR_SDK = OperatorSDK(version="1.4.2", download_path="/tmp")
+
+class LazyBin:
+    """
+    Abstraction around sretoolbox to avoid pulling binaries from the internet
+    before they actually need to be ran.
+    """
+
+    def __init__(self, bin_class, version, download_path):
+        self.bin_class = bin_class
+        self.version = version
+        self.download_path = download_path
+        self.instance = None
+
+    def run(self, cmd):
+        if self.instance is None:
+            self.instance = self.bin_class(self.version, self.download_path)
+
+        self.instance.run(*cmd)
+
+
+OPM = LazyBin(Opm, version="1.19.5", download_path="/tmp")
+MTCLI = LazyBin(Mtcli, version="0.10.0", download_path="/tmp")
+OPERATOR_SDK = LazyBin(OperatorSDK, version="1.4.2", download_path="/tmp")

--- a/managedtenants/bundles/bundle.py
+++ b/managedtenants/bundles/bundle.py
@@ -96,7 +96,7 @@ class Bundle:
     def _validate_operator_sdk(self):
         cmd = ["bundle", "validate", str(self.path)]
         try:
-            OPERATOR_SDK.run(*cmd)
+            OPERATOR_SDK.run(cmd)
         except subprocess.CalledProcessError as e:
             raise BundleError(
                 f"Failed to validate {self} with operator_sdk version"
@@ -106,7 +106,7 @@ class Bundle:
     def _validate_mtcli(self):
         cmd = ["bundle", "validate", str(self.path)]
         try:
-            MTCLI.run(*cmd)
+            MTCLI.run(cmd)
         except subprocess.CalledProcessError as e:
             raise BundleError(
                 f"Failed to validate {self} with mtcli version"

--- a/managedtenants/bundles/index_builder.py
+++ b/managedtenants/bundles/index_builder.py
@@ -61,7 +61,7 @@ class IndexBuilder:
         ]
 
         try:
-            OPM.run(*cmd)
+            OPM.run(cmd)
             self.docker_api.validate_image(index_image.url_tag)
             return index_image
 

--- a/managedtenants/cli/__init__.py
+++ b/managedtenants/cli/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from sretoolbox.utils.logger import get_text_logger
 
 from managedtenants import PostTask, PreTask, Task
+from managedtenants.bundles.cli import MtbundlesCLI
 from managedtenants.core import runner
 from managedtenants.core.addons_loader import load_addons
 from managedtenants.core.addons_loader.exceptions import AddonsLoaderError
@@ -249,11 +250,6 @@ class Cli:
             runner.run(tasks_factory=tasks_factory)
 
     def _build_bundles(self):
-        # lazy import because we have global vars that pull binaries
-        # using sretoolbox: bundles/binary_deps.py
-        # pylint:disable=import-outside-toplevel
-        from managedtenants.bundles.cli import MtbundlesCLI
-
         cli = MtbundlesCLI(args=self.args)
         cli.run()
 


### PR DESCRIPTION
# py-mtcli

## Description

Delay pulling sretoolbox binaries to the moment when they are needed.
