### PR TITLE
feat: adding aws.security_group_filters to requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,13 +24,13 @@ repos:
   #
   # Built-ins
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   # Black
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: ["--config", ".linters/black", "--experimental-string-processing"]

--- a/managedtenants/schemas/shared/addon_requirements.json
+++ b/managedtenants/schemas/shared/addon_requirements.json
@@ -34,6 +34,9 @@
             "type": "string",
             "format": "printable"
           },
+          "aws.security_group_filters": {
+            "type": "string"
+          },
           "aws.sts.enabled": {
             "type": "boolean"
           },


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- Made `aws.security_group_filters` available as a data key for addon requirements.

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
