### PR TITLE
Rename aws.security_group_filters to compute.security_group_filters

### DIFF
--- a/managedtenants/schemas/shared/addon_requirements.json
+++ b/managedtenants/schemas/shared/addon_requirements.json
@@ -34,9 +34,6 @@
             "type": "string",
             "format": "printable"
           },
-          "aws.security_group_filters": {
-            "type": "string"
-          },
           "aws.sts.enabled": {
             "type": "boolean"
           },
@@ -59,6 +56,9 @@
               "type": "string",
               "format": "printable"
             }
+          },
+          "compute.security_group_filters": {
+            "type": "string"
           },
           "compute.memory": {
             "type": "integer"


### PR DESCRIPTION
Signed-off-by: Nico Schieder <nschieder@redhat.com>

# py-mtcli

## Description

Renames `aws.security_group_filters` to `compute.security_group_filters` introduced in https://github.com/mt-sre/managed-tenants-cli/pull/143

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
