### PR TITLE
Fix: Ensure SQL catalog contains bundles.

### DIFF
--- a/tests/bundles/test_index_builder.py
+++ b/tests/bundles/test_index_builder.py
@@ -20,7 +20,11 @@ def test_index_builder_build_and_push():
         f"{REGISTRY_URL}/reference-addon-index:{hash_string}"
     )
 
-    index_builder = IndexBuilder(docker_api=docker_api)
-    index_image = index_builder.build_and_push(bundles, hash_string)
+    # (sblaisdo) need to skip validation because opm tries to query
+    # <registry_url>/v2/ and our quay.io registry doesn't support this workflow
+    index_builder = IndexBuilder(docker_api=docker_api, debug=True)
+    index_image = index_builder.build_and_push(
+        bundles, hash_string, skip_validation=True
+    )
 
     assert index_image.url_tag == expected_index_image_url


### PR DESCRIPTION
# py-mtcli

## Description

The codebase contained a bug where validating that a bundle image has Size > 0 is sufficient to ensure a bundle is properly built, but this is not sufficient for an index image.

This is because the index image will always have Size > 0 as it contains a whole alpine or busybox container depending on OPM's version used.

This fix proposes a deeper inspection by extracting the `/database/index.db` sqlite3 file from a container and ensuring the `properties` table contains bundles metadata.

## Checklist

**For any modification to `managedtenants/bundles/`**

- [x] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
