### PR TITLE
[MTSRE-528] Fix serviceMonitor CR in sss.

### DIFF
--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -87,6 +87,8 @@
 
 - **`monitoring`** *(object)*: Configuration parameters to be injected in the ServiceMonitor used for federation. The target prometheus server found by matchLabels needs to serve service-ca signed TLS traffic (https://docs.openshift.com/container-platform/4.6/security/certificate_types_descriptions/service-ca-certificates.html), and it needs to be runing inside the monitoring.namespace, with the service name 'prometheus'. Cannot contain additional properties.
 
+  - **`portName`** *(string)*: The name of the service port fronting the prometheus server. Default: `https`.
+
   - **`namespace`** *(string)*: Namespace where the prometheus server is running.
 
   - **`matchNames`** *(array)*: List of series names to federate from the prometheus server.

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -205,16 +205,14 @@ items:
         namespace: redhat-monitoring-{{ ADDON.metadata['id'] }}
       spec:
         endpoints:
-          - honorLabels: true
-            port: "9090"
+          - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honorLabels: true
+            port: {{ ADDON.metadata['monitoring']['portName'] }}
             path: /federate
             scheme: https
             interval: 30s
             tlsConfig:
-              ca:
-                configMap:
-                  name: openshift-service-ca.crt
-                  key: service-ca.crt
+              caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
               serverName: prometheus.{{ ADDON.metadata['monitoring']['namespace'] }}.svc
             params:
               'match[]':

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -138,8 +138,8 @@ properties:
           type: string
           description: "Url of the additional catalog source image"
       required:
-      - name
-      - image
+        - name
+        - image
   namespaceLabels:
     type: object
     items:
@@ -173,6 +173,11 @@ properties:
       - matchNames
       - matchLabels
     properties:
+      portName:
+        type: string
+        default: https
+        pattern: ^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$
+        description: "The name of the service port fronting the prometheus server."
       namespace:
         type: string
         pattern: ^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$


### PR DESCRIPTION
# py-mtcli

## Description

The ServiceMonitor generated by py-mtcli has some flaws:
- `portName` is not configurable
- Not using the `caFile` present in the "master" prometheus server (the one living in `openshift-monitoring`)
- Was not using a `bearerTokenFile`

All ServiceMonitor in managed openshift follow the same structure as the `openshift-apiserver` one, which is how we should model our configurations as well:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  annotations:
    include.release.openshift.io/ibm-cloud-managed: "true"
    include.release.openshift.io/self-managed-high-availability: "true"
    include.release.openshift.io/single-node-developer: "true"
  name: openshift-apiserver
  namespace: openshift-apiserver
spec:
  endpoints:
    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
      interval: 30s
      metricRelabelings:
        - action: drop
          regex: etcd_(debugging|disk|server).*
          sourceLabels:
            - __name__
        - action: drop
          regex: apiserver_admission_controller_admission_latencies_seconds_.*
          sourceLabels:
            - __name__
        - action: drop
          regex: apiserver_admission_step_admission_latencies_seconds_.*
          sourceLabels:
            - __name__
        - action: drop
          regex: apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)
          sourceLabels:
            - __name__
            - le
      port: https
      relabelings:
        - action: replace
          replacement: openshift-apiserver
          targetLabel: apiserver
      scheme: https
      tlsConfig:
        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
        serverName: api.openshift-apiserver.svc
  namespaceSelector:
    matchNames:
      - openshift-apiserver
  selector: {}
```