### PR TITLE
[MTSRE-528] monitoring.portName is required.

### DIFF
--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -87,7 +87,7 @@
 
 - **`monitoring`** *(object)*: Configuration parameters to be injected in the ServiceMonitor used for federation. The target prometheus server found by matchLabels needs to serve service-ca signed TLS traffic (https://docs.openshift.com/container-platform/4.6/security/certificate_types_descriptions/service-ca-certificates.html), and it needs to be runing inside the monitoring.namespace, with the service name 'prometheus'. Cannot contain additional properties.
 
-  - **`portName`** *(string)*: The name of the service port fronting the prometheus server. Default: `https`.
+  - **`portName`** *(string)*: The name of the service port fronting the prometheus server.
 
   - **`namespace`** *(string)*: Namespace where the prometheus server is running.
 

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -169,13 +169,13 @@ properties:
     description: "Configuration parameters to be injected in the ServiceMonitor used for federation. The target prometheus server found by matchLabels needs to serve service-ca signed TLS traffic (https://docs.openshift.com/container-platform/4.6/security/certificate_types_descriptions/service-ca-certificates.html), and it needs to be runing inside the monitoring.namespace, with the service name 'prometheus'."
     additionalProperties: false
     required:
+      - portName
       - namespace
       - matchNames
       - matchLabels
     properties:
       portName:
         type: string
-        default: https
         pattern: ^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$
         description: "The name of the service port fronting the prometheus server."
       namespace:


### PR DESCRIPTION
# py-mtcli

## Description

The `default` field in JSON schema is only informative. Making `portName` required.

## Checklist

There will be an accompanying MR in `managed-tenants` internal repo. The only addon using the `monitoring:` feature is `ocs-provider-dev` so it was quite easy to test + validate.

- [x] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons load` (successfully load all addons)
