### PR TITLE
[MTSRE-290] Add description to all JSON schema fields in managed-tenants

### DIFF
--- a/docs/tenants/zz_imageset_schema_generated.md
+++ b/docs/tenants/zz_imageset_schema_generated.md
@@ -15,10 +15,10 @@
 
   - **Items** *(string)*
 
-- **`addOnParameters`**: Refer to *shared/addon_parameters.json*.
+- **`addOnParameters`**: List of parameters for the addon. Refer to *shared/addon_parameters.json*.
 
-- **`addOnRequirements`**: Refer to *shared/addon_requirements.json*.
+- **`addOnRequirements`**: List of requirements for the addon. Refer to *shared/addon_requirements.json*.
 
-- **`subOperators`**: Refer to *shared/sub_operators.json*.
+- **`subOperators`**: Sub operator under the umbrella of add-on operator. Refer to *shared/sub_operators.json*.
 
-- **`subscriptionConfig`**: Refer to *shared/subscription_config.json*.
+- **`subscriptionConfig`**: Subscription config of the addons for the OLM object. Refer to *shared/subscription_config.json*.

--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -165,14 +165,14 @@
 
   - **Items** *(string)*
 
-- **`credentialsRequests`**: Refer to *shared/credentials_requests.json*.
+- **`credentialsRequests`**: List of credential requests to authenticate operators. Refer to *shared/credentials_requests.json*.
 
-- **`addOnParameters`**: Refer to *shared/addon_parameters.json*.
+- **`addOnParameters`**: List of parameters for the addon. Refer to *shared/addon_parameters.json*.
 
-- **`addOnRequirements`**: Refer to *shared/addon_requirements.json*.
+- **`addOnRequirements`**: List of requirements for the addon. Refer to *shared/addon_requirements.json*.
 
-- **`subOperators`**: Refer to *shared/sub_operators.json*.
+- **`subOperators`**: Sub operator under the umbrella of add-on operator. Refer to *shared/sub_operators.json*.
 
-- **`subscriptionConfig`**: Refer to *shared/subscription_config.json*.
+- **`subscriptionConfig`**: Subscription config of the addons for the OLM object. Refer to *shared/subscription_config.json*.
 
 - **`managedService`** *(boolean)*: Indicates if the add-on will be used as a Managed Service.

--- a/docs/tenants/zz_mtbundles_schema_generated.md
+++ b/docs/tenants/zz_mtbundles_schema_generated.md
@@ -9,13 +9,13 @@
 
 - **`ocm`** *(object)*: Required OCM data for valid imagesets to be constructed by automated MRs to managed-tenants. Cannot contain additional properties.
 
-  - **`addOnParameters`**: Refer to *shared/addon_parameters.json*.
+  - **`addOnParameters`**: List of parameters for the addon. Refer to *shared/addon_parameters.json*.
 
-  - **`addOnRequirements`**: Refer to *shared/addon_requirements.json*.
+  - **`addOnRequirements`**: List of requirements for the addon. Refer to *shared/addon_requirements.json*.
 
-  - **`subOperators`**: Refer to *shared/sub_operators.json*.
+  - **`subOperators`**: Sub operator under the umbrella of add-on operator. Refer to *shared/sub_operators.json*.
 
-  - **`subscriptionConfig`**: Refer to *shared/subscription_config.json*.
+  - **`subscriptionConfig`**: Subscription config of the addons for the OLM object. Refer to *shared/subscription_config.json*.
 
 - **`addons`** *(array)*: List of addons that use these underlying bundles.
 

--- a/managedtenants/schemas/imageset.schema.yaml
+++ b/managedtenants/schemas/imageset.schema.yaml
@@ -6,28 +6,28 @@ properties:
   name:
     type: string
     pattern: ^[a-z-]+.v[0-9A-Za-z\.-]+$
-    description: "The name of the imageset along with the version"
+    description: "The name of the imageset along with the version."
   indexImage:
     type: string
     pattern: ^quay\.io/osd-addons/[a-z-]+
-    description: "The url for the index image"
+    description: "The url for the index image."
   relatedImages:
     type: array
-    description: "A list of image urls of related operators"
+    description: "A list of image urls of related operators."
     items:
       type: string
   addOnParameters:
     $ref: "shared/addon_parameters.json"
-    description: "List of parameters for the addon"
+    description: "List of parameters for the addon."
   addOnRequirements:
     $ref: "shared/addon_requirements.json"
-    description: "List of requirements for the addon"
+    description: "List of requirements for the addon."
   subOperators:
     $ref: "shared/sub_operators.json"
-    description: "Sub operator under the umbrella of add-on operator"
+    description: "Sub operator under the umbrella of add-on operator."
   subscriptionConfig:
     $ref: "shared/subscription_config.json"
-    description: "Subscription config of the addons for the OLM object"
+    description: "Subscription config of the addons for the OLM object."
 required:
   - name
   - indexImage

--- a/managedtenants/schemas/imageset.schema.yaml
+++ b/managedtenants/schemas/imageset.schema.yaml
@@ -18,12 +18,16 @@ properties:
       type: string
   addOnParameters:
     $ref: "shared/addon_parameters.json"
+    description: "List of parameters for the addon"
   addOnRequirements:
     $ref: "shared/addon_requirements.json"
+    description: "List of requirements for the addon"
   subOperators:
     $ref: "shared/sub_operators.json"
+    description: "Sub operator under the umbrella of add-on operator"
   subscriptionConfig:
     $ref: "shared/subscription_config.json"
+    description: "Subscription config of the addons for the OLM object"
 required:
   - name
   - indexImage

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -68,7 +68,7 @@ properties:
       - "rollback step 1 - ocm"
       - "rollback step 2 - selectorsyncset"
       - "rollback step 3 - reset addon migration"
-    description: "The step currently in consideration in the process of migrating the addon to SyncSet"
+    description: "The step currently in consideration in the process of migrating the addon to SyncSet."
   manualInstallPlanApproval:
     type: boolean
   targetNamespace:
@@ -125,7 +125,7 @@ properties:
     description: Name of the secret under `secrets` which is supposed to be used for pulling Catalog Image under CatalogSource.
   additionalCatalogSources:
     type: array
-    description: "List of additional catalog sources to be created"
+    description: "List of additional catalog sources to be created."
     items:
       type: object
       additionalProperties: false
@@ -133,10 +133,10 @@ properties:
         name:
           type: string
           format: printable
-          description: "Name of the additional catalog source"
+          description: "Name of the additional catalog source."
         image:
           type: string
-          description: "Url of the additional catalog source image"
+          description: "Url of the additional catalog source image."
       required:
         - name
         - image
@@ -323,14 +323,19 @@ properties:
     description: "Extra Resources to be applied to the Hive cluster."
   credentialsRequests:
     $ref: "shared/credentials_requests.json"
+    description: "List of credential requests to authenticate operators."
   addOnParameters:
     $ref: "shared/addon_parameters.json"
+    description: "List of parameters for the addon."
   addOnRequirements:
     $ref: "shared/addon_requirements.json"
+    description: "List of requirements for the addon."
   subOperators:
     $ref: "shared/sub_operators.json"
+    description: "Sub operator under the umbrella of add-on operator."
   subscriptionConfig:
     $ref: "shared/subscription_config.json"
+    description: "Subscription config of the addons for the OLM object."
   managedService:
     type: boolean
     description: "Indicates if the add-on will be used as a Managed Service."

--- a/managedtenants/schemas/mtbundles.schema.yaml
+++ b/managedtenants/schemas/mtbundles.schema.yaml
@@ -10,12 +10,16 @@ properties:
     properties:
       addOnParameters:
         $ref: "shared/addon_parameters.json"
+        description: "List of parameters for the addon."
       addOnRequirements:
         $ref: "shared/addon_requirements.json"
+        description: "List of requirements for the addon."
       subOperators:
         $ref: "shared/sub_operators.json"
+        description: "Sub operator under the umbrella of add-on operator."
       subscriptionConfig:
         $ref: "shared/subscription_config.json"
+        description: "Subscription config of the addons for the OLM object."
   addons:
     type: array
     description: "List of addons that use these underlying bundles."


### PR DESCRIPTION
Signed-off-by: Ankit kurmi <akurmi@redhat.com>

# py-mtcli

## Description

Short description of the change:

- Adding description to all the JSON schema fields in managed-tenants [MTSRE-290](https://issues.redhat.com/browse/MTSRE-290)