### PR TITLE
Remove Addon CR from the generated SSS as it is created by OCM.

### DIFF
--- a/managedtenants/core/addons_loader/sss.py
+++ b/managedtenants/core/addons_loader/sss.py
@@ -185,6 +185,10 @@ class SssWalker:
         sss = deepcopy(data)
         old_resources = deepcopy(data["spec"]["resources"])
         sss["spec"]["resources"] = defaultdict(list)
+
+        if old_resources is None:
+            return sss
+
         for resource in old_resources:
             kind = resource["kind"]
             name = resource["metadata"]["name"]

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -232,7 +232,7 @@ items:
             {{ expand_dict(ADDON.metadata['monitoring']['matchLabels']) | indent(12) }}
 {% endif %}
 
-{# addon v2 create the Addon CR #}
+{# addon v2 Addon CR is created by OCM, only secret management handled by SSS #}
 {% elif ADDON.manager == AddonManager.ADDON_OPERATOR %}
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -245,34 +245,6 @@ items:
     resourceApplyMode: Sync
 
     resources:
-{% if (ADDON.metadata.get('indexImage') or ADDON.imageset) %}
-    - apiVersion: addons.managed.openshift.io/v1alpha1
-      kind: Addon
-      metadata:
-        name: {{ADDON.metadata['id']}}
-      spec:
-        displayName: {{ADDON.metadata['name']}}
-        namespaces:
-{% for namespace in ADDON.metadata['namespaces'] %}
-        - name: {{namespace}}
-{% endfor %}
-        install:
-          type: OLMOwnNamespace
-          olmOwnNamespace:
-            namespace: {{ADDON.metadata['targetNamespace']}}
-            packageName: {{ADDON.metadata['operatorName']}}
-            channel: {{ADDON.metadata['defaultChannel']}}
-            catalogSourceImage: {{ADDON.metadata.get('indexImage') or ADDON.imageset['indexImage']}}
-            {% if ADDON.get_subscription_config() %}
-            config:
-              env:
-              {% for env_obj in ADDON.get_subscription_config().get("env") %}
-              - name: {{env_obj['name']}}
-                value: |-
-                  {{env_obj['value']}}
-              {% endfor %}
-            {% endif %}
-{% endif %}
 {# TODO: move pullsecret management into the addon-operator #}
 {% for namespace in ADDON.metadata['namespaces'] %}
     {% if ADDON.metadata['pullSecret'] is defined %}

--- a/tests/sss/test_catalogue_source.py
+++ b/tests/sss/test_catalogue_source.py
@@ -8,7 +8,6 @@ from tests.testutils.addon_helpers import (  # noqa: F401
     addon_with_indeximage_path,
     addon_with_pagerduty,
     addon_with_secrets_path,
-    addons_managed_by_addon_cr,
 )
 
 
@@ -17,41 +16,23 @@ from tests.testutils.addon_helpers import (  # noqa: F401
     [
         "addon_with_indeximage",
         "addon_with_imageset",
-        "addons_managed_by_addon_cr",
         "addon_with_deadmanssnitch",
         "addon_with_pagerduty",
     ],
 )
 def test_addon_sss_object(addon_str, request):
     """Test that addon metadata is loaded."""
-    if addon_str == "addons_managed_by_addon_cr":
-        addons = request.getfixturevalue(addon_str)
-        for addon in addons:
-            sss_walker = addon.sss.walker()
-            addon_cr_obj = sss_walker["sss_deploy"]["spec"]["resources"][
-                "Addon"
-            ]
-            assert len(addon_cr_obj) == 1
-            name, data = addon_cr_obj[0]
-            assert name is not None
-            assert data is not None
-            assert data["spec"] is not None
-            catalogue_src_image = data["spec"]["install"]["olmOwnNamespace"][
-                "catalogSourceImage"
-            ]
-            assert catalogue_src_image is not None
-    else:
-        addon = request.getfixturevalue(addon_str)
-        sss_walker = addon.sss.walker()
-        catalogue_src_obj = sss_walker["sss_deploy"]["spec"]["resources"][
-            "CatalogSource"
-        ]
-        assert len(catalogue_src_obj) == 1
-        name, data = catalogue_src_obj[0]
-        assert name is not None
-        assert data is not None
-        assert data["spec"]["image"] is not None
-        assert data["spec"].get("secrets") is None
+    addon = request.getfixturevalue(addon_str)
+    sss_walker = addon.sss.walker()
+    catalogue_src_obj = sss_walker["sss_deploy"]["spec"]["resources"][
+        "CatalogSource"
+    ]
+    assert len(catalogue_src_obj) == 1
+    name, data = catalogue_src_obj[0]
+    assert name is not None
+    assert data is not None
+    assert data["spec"]["image"] is not None
+    assert data["spec"].get("secrets") is None
 
 
 def test_additional_catalog_srcs():

--- a/tests/sss/test_subscription_config.py
+++ b/tests/sss/test_subscription_config.py
@@ -2,18 +2,11 @@ import pytest
 
 from tests.testutils.addon_helpers import addon_with_imageset  # noqa: F401
 from tests.testutils.addon_helpers import addon_with_indeximage  # noqa: F401
-from tests.testutils.addon_helpers import (  # noqa: F401
-    addons_managed_by_addon_cr,
-)
 
 
 @pytest.mark.parametrize(
     "addon_str",
-    [
-        "addon_with_indeximage",
-        "addon_with_imageset",
-        "addons_managed_by_addon_cr",
-    ],
+    ["addon_with_indeximage", "addon_with_imageset"],
 )
 def test_subscription_config(addon_str, request):
     expected_values = [
@@ -21,36 +14,17 @@ def test_subscription_config(addon_str, request):
         {"name": "USER", "value": "Gordon Freeman"},
         {"name": "HUMAN", "value": "true"},
     ]
-
-    if addon_str == "addons_managed_by_addon_cr":
-        addons = request.getfixturevalue(addon_str)
-        for addon in addons:
-            sss_walker = addon.sss.walker()
-            addon_cr_obj = sss_walker["sss_deploy"]["spec"]["resources"][
-                "Addon"
-            ]
-            assert len(addon_cr_obj) == 1
-            name, data = addon_cr_obj[0]
-            assert name is not None
-            assert data is not None
-            assert data["spec"] is not None
-            subscription_config = data["spec"]["install"]["olmOwnNamespace"][
-                "config"
-            ]
-            assert subscription_config is not None
-            assert subscription_config["env"] == expected_values
+    addon = request.getfixturevalue(addon_str)
+    sss_walker = addon.sss.walker()
+    subscription_obj = sss_walker["sss_deploy"]["spec"]["resources"][
+        "Subscription"
+    ][0]
+    if addon.get_subscription_config():
+        _, subscription_contents = subscription_obj
+        assert len(subscription_contents["spec"]["config"]["env"]) == 3
+        for env_obj in subscription_contents["spec"]["config"]["env"]:
+            assert env_obj in expected_values
     else:
-        addon = request.getfixturevalue(addon_str)
-        sss_walker = addon.sss.walker()
-        subscription_obj = sss_walker["sss_deploy"]["spec"]["resources"][
-            "Subscription"
-        ][0]
-        if addon.get_subscription_config():
-            _, subscription_contents = subscription_obj
-            assert len(subscription_contents["spec"]["config"]["env"]) == 3
-            for env_obj in subscription_contents["spec"]["config"]["env"]:
-                assert env_obj in expected_values
-        else:
-            _, subscription_contents = subscription_obj
-            res = subscription_contents["spec"].get("config")
-            assert res is None
+        _, subscription_contents = subscription_obj
+        res = subscription_contents["spec"].get("config")
+        assert res is None

--- a/tests/testutils/addon_helpers.py
+++ b/tests/testutils/addon_helpers.py
@@ -67,17 +67,6 @@ def addon_with_indeximage():
 
 
 @pytest.fixture
-def addons_managed_by_addon_cr():
-    def create_addon_managed_by_addon_cr(path):
-        return Addon(
-            path, "stage", override_manager=AddonManager.ADDON_OPERATOR
-        )
-
-    addon_paths = [addon_with_imageset_path(), addon_with_indeximage_path()]
-    return list(map(create_addon_managed_by_addon_cr, addon_paths))
-
-
-@pytest.fixture
 def addon_with_imageset():
     addon_path = addon_with_imageset_path()
     return Addon(addon_path, "stage")


### PR DESCRIPTION
# py-mtcli

## Description

OCM is responsible to create the Addon CR in clusters. We can safely remove it from the generated SSS when the `ADDON.manager == AddonManager.ADDON_OPERATOR` to avoid confusion and unecessary feature parity PRs.

ref: https://github.com/mt-sre/managed-tenants-cli/pull/158

cc @apahim 