### PR TITLE
MTSRE-489 Bundles use digest format

### DIFF
--- a/managedtenants/bundles/index_builder.py
+++ b/managedtenants/bundles/index_builder.py
@@ -60,7 +60,7 @@ class IndexBuilder:
             "add",
             "--permissive",
             "--bundles",
-            ",".join([bundle.image.url_tag for bundle in bundles]),
+            ",".join([bundle.image.url_digest for bundle in bundles]),
             "--tag",
             index_image.url_tag,
         ]

--- a/managedtenants/bundles/index_builder.py
+++ b/managedtenants/bundles/index_builder.py
@@ -60,7 +60,14 @@ class IndexBuilder:
             "add",
             "--permissive",
             "--bundles",
-            ",".join([bundle.image.url_digest for bundle in bundles]),
+            ",".join(
+                [
+                    bundle.image.url_digest
+                    if not skip_validation
+                    else bundle.image.url_tag
+                    for bundle in bundles
+                ]
+            ),
             "--tag",
             index_image.url_tag,
         ]


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

Changed the tag format used by bundles to digest format.