### PR TITLE
[MTSRE-534] Create CatlogSource in the targetNamespace

### DIFF
--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -128,7 +128,7 @@ items:
         channel: {{ADDON.metadata['defaultChannel']}}
         name: {{ADDON.metadata['id']}}
         source: addon-{{ADDON.metadata['id']}}-catalog
-        sourceNamespace: openshift-marketplace
+        sourceNamespace: {{ADDON.metadata['targetNamespace']}}
         {% if ADDON.get_subscription_config() %}
         config:
           env:

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -66,7 +66,7 @@ items:
       kind: CatalogSource
       metadata:
         name: addon-{{ADDON.metadata['id']}}-catalog
-        namespace: openshift-marketplace
+        namespace: {{ADDON.metadata["targetNamespace"]}}
         {{ maybe_annotations(ADDON.metadata.get('commonAnnotations')) | indent(8) }}
         {{ maybe_labels(ADDON.metadata.get('commonLabels')) | indent(8) }}
       spec:


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

# py-mtcli

## Description

Short description of the change:

- Currently the SSS creates the CatalogSource in the openshift-marketplace namespace. We should use the targetNamespace instead:
https://github.com/mt-sre/managed-tenants-cli/blob/main/managedtenants/data/selectorsyncset.yaml.j2#L117

- addon-operator already does the right thing:
https://github.com/openshift/addon-operator/blob/main/internal/controllers/addon/phase_ensure_catalogsource.go#L33-L49


Added fix for the jinja template.