### PR TITLE
Modify ocm client

### DIFF
--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -206,7 +206,6 @@ class OcmCli:
             addon_id,
             {
                 "enabled": True,
-                "rollback_migration": False,
             },
         )
 


### PR DESCRIPTION
Dont send rollback_migration attr as part of the json payload as part of enabling addon migration

Signed-off-by: ashish <asnaraya@redhat.com>

