### PR TITLE
Create a NetworkPolicy to grant explicit access to addon CatalogSources

### DIFF
--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -102,6 +102,32 @@ items:
 {% endfor %}
 {% endif %}
 
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: addon-{{ADDON.metadata['id']}}-catalogs
+        namespace: {{ADDON.metadata["targetNamespace"]}}
+        {{ maybe_annotations(ADDON.metadata.get('commonAnnotations')) | indent(8) }}
+        {{ maybe_labels(ADDON.metadata.get('commonLabels')) | indent(8) }}
+      spec:
+        podSelector:
+          matchExpressions:
+            - key: olm.catalogSource
+              operator: In
+              values:
+                - addon-{{ADDON.metadata['id']}}-catalog
+{% if ADDON.metadata['additionalCatalogSources'] is defined %}
+{% for catalog_src in ADDON.metadata['additionalCatalogSources'] %}
+                - {{catalog_src["name"]}}
+{% endfor %}
+{% endif %}
+        ingress:
+          - ports:
+              - protocol: TCP
+                port: 50051
+        policyTypes:
+          - Ingress
+
 {% if ADDON.metadata['namespaces'] %}
     - apiVersion: operators.coreos.com/v1alpha2
       kind: OperatorGroup


### PR DESCRIPTION
Signed-off-by: Nico Schieder <nschieder@redhat.com>

# py-mtcli

## Description
Adds a `NetworkPolicy` to every SyncSet to allow explicit access to the CatalogSource pods.
Without this policy in place, addon firewalling might prevent access, which in turn prevents the addon from being upgraded.

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
