### PR TITLE
Change Image Format

### DIFF
--- a/managedtenants/bundles/index_builder.py
+++ b/managedtenants/bundles/index_builder.py
@@ -65,7 +65,8 @@ class IndexBuilder:
             "--binary-image",
             # Custom base image based on UBI, OPM 1.19.5
             # https://github.com/mt-sre/containers/tree/main/opm-ubi
-            "quay.io/mtsre/opm-ubi@sha256:d687f6f03521968148428ad8728f6841ffed055480d86eb0ba732af45a357b3b",  # noqa: 501
+            # TODO - return back to using digest once the issue of tag overwrites is sorted with mt-sre/containers # noqa: 501
+            "quay.io/mtsre/opm-ubi:v1.19.5",
             "--permissive",
             "--bundles",
             ",".join([bundle.image.url_tag for bundle in bundles]),


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- Changed image digest format to tag format here: https://github.com/rpriyanshu9/managed-tenants-cli/blob/cbd83857b460088dd5828b8264d3f1ee70391295/managedtenants/bundles/index_builder.py#L68.
- This is done because every time the image gets pushed/updated here https://quay.io/repository/mtsre/opm-ubi, the digest will change and we'd have to manually update it in our code. 
