### PR TITLE
Bumping base image in Dockerfile.test to ubi9

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # vi:set ft=dockerfile:
-FROM registry.access.redhat.com/ubi8/python-39:latest
+FROM registry.access.redhat.com/ubi9/python-39:latest
 
 ENV CI=true
 USER root


### PR DESCRIPTION
Signed-off-by: Priyanshu Raj <prraj@redhat.com>

# py-mtcli

## Description

Short description of the change:

Bumping base image in Dockerfile.test to ubi9 to avoid dependency issues.
eg. https://ci.ext.devshift.net/job/mt-sre-managed-tenants-cli-gh-pr-check/388/console