### PR TITLE
refactor: Moving named volume from pr_check.sh to `test` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,13 @@ check: pylint
 	pipenv run flake8 --config=$(LINTERS)/flake8 $(PY_SRCS) && \
 	pipenv run yamllint --config-file=$(LINTERS)/yamllint .
 
+MINIMAL_IMAGE := registry.access.redhat.com/ubi8/ubi-minimal@sha256:e83a3146aa8d34dccfb99097aa79a3914327942337890aa6f73911996a80ebb8
 test:
+	docker container create --name storageContainer -v sharedCertsVol:/certs $(MINIMAL_IMAGE)
+	docker cp ./managedtenants/bundles/certs/. storageContainer:/certs
+	docker rm storageContainer
 	pipenv run pytest --cache-clear -v tests/
+	docker volume rm sharedCertsVol
 
 release:
 	python -m pip install twine wheel

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -9,11 +9,8 @@ docker build -t ${IMAGE_TEST} -f Dockerfile.test .
 docker_run_args=(
     --rm
     -v "/var/run/docker.sock:/var/run/docker.sock"
-    -v "sharedCertsVol:/managedtenant-cli/managedtenants/bundles/certs"
     --net "host"
 )
 
 
 docker run "${docker_run_args[@]}" "${IMAGE_TEST}" check test
-
-docker volume rm sharedCertsVol


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

Moving named volume logic to Makefile's `test` target.