### PR TITLE
new method to check if addon migration exists

### DIFF
--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -165,6 +165,14 @@ class OcmCli:
     def get_addon_migrations(self):
         return self._get("/api/clusters_mgmt/v1/addon_migrations")
 
+    def check_addon_migration_exists(self, addon_id):
+        try:
+            self._get(f"/api/clusters_mgmt/v1/addon_migrations/{addon_id}")
+            return True
+        # `_get` raises OCMAPIError on 404's
+        except OCMAPIError:
+            return False
+
     def get_addon_migration(self, addon_id):
         return self._get(f"/api/clusters_mgmt/v1/addon_migrations/{addon_id}")
 


### PR DESCRIPTION
Signed-off-by: ashish <asnaraya@redhat.com>

This PR adds a new method to check if addon migration exists in ocm. The idea is to use this method in the mt gitlab repo instead of `get_addon_migration` which raises an exception on 404's.
