### PR TITLE
Map `addonParameters` from metadata when imageset present

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   #
   # Built-ins
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -300,9 +300,16 @@ class OcmCli:
                     metadata.get("subscriptionConfig").get("env")
                 )
 
+        if metadata.get("addOnParameters"):
+            mapped_key = self.IMAGESET_KEYS["addOnParameters"]
+            addon[mapped_key] = self._parameters_from_list(
+                metadata.get("addOnParameters")
+            )
+
         for key, val in imageset.items():
-            mapped_key = self.IMAGESET_KEYS[key]
             if key in self.IMAGESET_KEYS:
+                mapped_key = self.IMAGESET_KEYS[key]
+
                 if key == "additionalCatalogSources":
                     catalog_src_list = self.index_dicts(val)
                     addon[mapped_key] = catalog_src_list
@@ -317,12 +324,7 @@ class OcmCli:
                         ] = env_var_list
                     continue
                 if key == "addOnParameters":
-                    # Enforce a sort order field on addon parameters
-                    # so that they can be shown in the same order as
-                    # the imageset file.
-                    for index, param in enumerate(val):
-                        param["order"] = index
-                    val = {"items": val}
+                    val = self._parameters_from_list(val)
                 addon[mapped_key] = val
         return addon
 
@@ -331,8 +333,9 @@ class OcmCli:
         metadata["addOnParameters"] = metadata.get("addOnParameters", [])
         metadata["addOnRequirements"] = metadata.get("addOnRequirements", [])
         for key, val in metadata.items():
-            mapped_key = self.ADDON_KEYS[key]
             if key in self.ADDON_KEYS:
+                mapped_key = self.ADDON_KEYS[key]
+
                 # Skip adding these parameters as they're present
                 # in the ImageSet (versions endpoint)
                 if metadata.get("addonImageSetVersion") and key in [
@@ -344,12 +347,7 @@ class OcmCli:
                 if key == "installMode":
                     val = _camel_to_snake_case(val)
                 if key == "addOnParameters":
-                    # Enforce a sort order field on addon parameters
-                    # so that they can be shown in the same order as
-                    # the metadata file.
-                    for index, param in enumerate(val):
-                        param["order"] = index
-                    val = {"items": val}
+                    val = self._parameters_from_list(val)
                 if key == "subscriptionConfig":
                     if val.get("env"):
                         addon[mapped_key] = {}
@@ -362,6 +360,14 @@ class OcmCli:
                     continue
                 addon[mapped_key] = val
         return addon
+
+    def _parameters_from_list(self, params):
+        # Enforce a sort order field on addon parameters
+        # so that they can be shown in the same order as
+        # the metadata file.
+        for index, param in enumerate(params):
+            param["order"] = index
+        return {"items": params}
 
     @staticmethod
     def index_dicts(dicts):

--- a/tests/testdata/addons/mock-operator-with-imagesets/addonimagesets/stage/mock-operator.v1.0.1.yml
+++ b/tests/testdata/addons/mock-operator-with-imagesets/addonimagesets/stage/mock-operator.v1.0.1.yml
@@ -1,0 +1,24 @@
+name: mock-operator.v1.0.1
+indexImage: quay.io/osd-addons/mock-operator-index@sha256:...
+relatedImages:
+ - quay.io/osd-addons/mock-operator@sha256:...
+ - quay.io/osd-addons/mock-operator@sha256:...
+ - quay.io/osd-addons/mock-operator@sha256:...
+addOnParameters:
+  - id: size
+    name: Managed StorageCluster size
+    description:
+      The size, in terabytes, of the Storage Cluster to be deployed. Currently
+      1 or 4 are supported.
+    value_type: resource_requirement
+    required: true
+    editable: true
+    enabled: true
+  - id: duration
+    name: Managed StorageCluster duration
+    description:
+      How long until the Storage Cluster will be deleted.
+    value_type: number
+    required: true
+    editable: true
+    enabled: true

--- a/tests/testutils/addon_helpers.py
+++ b/tests/testutils/addon_helpers.py
@@ -126,6 +126,21 @@ def addon_with_imageset_and_default_config():
 
 
 @pytest.fixture
+def addon_with_imageset_and_parameter_config():
+    addon_path = addon_with_imageset_path()
+    addon = Addon(addon_path, "stage")
+    updated_metadata = addon.metadata
+    # Set imageset to a version that doesnt have
+    # subscription config
+    updated_metadata["addonImageSetVersion"] = "1.0.1"
+    addon.metadata = updated_metadata
+    addon.imageset_version = "1.0.1"
+    # Reload imageset
+    addon.imageset = addon.load_imageset("1.0.1")
+    return addon
+
+
+@pytest.fixture
 def addon_with_bundles():
     addon_path = addon_with_bundles_path()
     return Addon(addon_path, "stage")

--- a/tests/utils/test_ocm.py
+++ b/tests/utils/test_ocm.py
@@ -1,0 +1,109 @@
+from io import StringIO
+
+import pytest
+from jsonschema.exceptions import SchemaError
+
+from managedtenants.data.paths import SCHEMAS_DIR
+from managedtenants.utils.ocm import OcmCli
+from tests.testutils.addon_helpers import (  # noqa: F401; noqa: F401; flake8: noqa: F401
+    addon_with_imageset_and_default_config,
+    addon_with_imageset_and_multiple_config,
+    addon_with_imageset_and_parameter_config,
+    addon_with_indeximage,
+    addon_with_only_imageset_config,
+)
+
+
+@pytest.mark.parametrize(
+    "addon_str,expected_result",
+    [
+        (
+            "addon_with_imageset_and_default_config",
+            [{"id": "0", "name": "DEFAULT", "value": "TRUE"}],
+        ),
+        (
+            "addon_with_imageset_and_multiple_config",
+            [
+                {
+                    "id": "0",
+                    "name": "LOCATION",
+                    "value": "Black Mesa Research Facility",
+                },
+                {"id": "1", "name": "USER", "value": "Gordon Freeman"},
+                {"id": "2", "name": "HUMAN", "value": "true"},
+            ],
+        ),
+        (
+            "addon_with_only_imageset_config",
+            [
+                {
+                    "id": "0",
+                    "name": "LOCATION",
+                    "value": "Black Mesa Research Facility",
+                },
+                {"id": "1", "name": "USER", "value": "Gordon Freeman"},
+                {"id": "2", "name": "HUMAN", "value": "true"},
+            ],
+        ),
+        (
+            "addon_with_indeximage",
+            [
+                {
+                    "id": "0",
+                    "name": "LOCATION",
+                    "value": "Black Mesa Research Facility",
+                },
+                {"id": "1", "name": "USER", "value": "Gordon Freeman"},
+                {"id": "2", "name": "HUMAN", "value": "true"},
+            ],
+        ),
+    ],
+)
+def test_ocm_addon_environment_variables(addon_str, expected_result, request):
+    addon = request.getfixturevalue(addon_str)
+    ocm_cli = OcmCli(offline_token=None)
+    if addon.imageset:
+        ocm_addon = ocm_cli._addon_from_imageset(
+            imageset=addon.imageset, metadata=addon.metadata
+        )
+    else:
+        ocm_addon = ocm_cli._addon_from_metadata(metadata=addon.metadata)
+
+    assert (
+        ocm_addon.get("config").get("add_on_environment_variables")
+        == expected_result
+    )
+
+
+@pytest.mark.parametrize(
+    "addon_str,expected_result",
+    [
+        (
+            "addon_with_imageset_and_default_config",
+            [{"id": "size"}],
+        ),
+        (
+            "addon_with_imageset_and_parameter_config",
+            [{"id": "size"}, {"id": "duration"}],
+        ),
+    ],
+)
+def test_ocm_addon_parameters(addon_str, expected_result, request):
+    addon = request.getfixturevalue(addon_str)
+    ocm_cli = OcmCli(offline_token=None)
+    if addon.imageset:
+        ocm_addon = ocm_cli._addon_from_imageset(
+            imageset=addon.imageset, metadata=addon.metadata
+        )
+    else:
+        ocm_addon = ocm_cli._addon_from_metadata(metadata=addon.metadata)
+
+    params = ocm_addon.get("parameters")
+    assert params is not None
+    items = params.get("items")
+    assert items is not None
+
+    assert len(items) == len(expected_result)
+
+    for idx, item in enumerate(items):
+        assert item["id"] == expected_result[idx]["id"]


### PR DESCRIPTION
# py-mtcli

## Description

Map `addonParameters` from `metadata` when `imageset` present
- modified `ocm.py` to get `addonParameters` from `metadata` (may be overridden by same key in `imageset`)
- add common function to map `addonParameters` to `parameters` object for OCM addon
- tests

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
