### PR TITLE
[MTSRE-586] fix: use `--build-with tag` in dry-run mode

### DIFF
--- a/managedtenants/bundles/cli.py
+++ b/managedtenants/bundles/cli.py
@@ -104,6 +104,7 @@ class MtbundlesCLI:
             docker_api=self.docker_api,
             dry_run=self.args.dry_run,
             debug=self.args.debug,
+            build_with=self.args.build_with,
         )
 
     def _init_imageset_creator(self):

--- a/managedtenants/bundles/index_builder.py
+++ b/managedtenants/bundles/index_builder.py
@@ -17,9 +17,11 @@ class IndexBuilder:
         docker_api,
         dry_run=False,
         debug=False,
+        build_with="digest",
     ):
         self.dry_run = dry_run
         self.docker_api = docker_api
+        self.build_with = build_with
         self.log = get_text_logger(
             "managedtenants-index-builder",
             level=logging.DEBUG if debug else logging.INFO,
@@ -68,7 +70,14 @@ class IndexBuilder:
             "quay.io/mtsre/opm-ubi@sha256:471dc5652a045103d75bafd24072926fbd7a520bd613cee896f2ce1602316eac",  # noqa: 501
             "--permissive",
             "--bundles",
-            ",".join([bundle.image.url_digest for bundle in bundles]),
+            ",".join(
+                [
+                    bundle.image.url_tag
+                    if self.build_with == "tag"
+                    else bundle.image.url_digest
+                    for bundle in bundles
+                ]
+            ),
             "--tag",
             index_image.url_tag,
         ]

--- a/managedtenants/cli/__init__.py
+++ b/managedtenants/cli/__init__.py
@@ -94,7 +94,8 @@ class Cli:
         bundles_parser_examples = [
             "Examples:",
             "# Build all bundles and index images locally.",
-            "$ managedtenants --addons-dir=PATH --dry-run bundles",
+            "$ managedtenants --addons-dir=PATH --dry-run bundles"
+            " --build-with tag",
             "",
             "# Build and push all bundles and index images to a custom quay"
             " org.",
@@ -112,8 +113,9 @@ class Cli:
             formatter_class=argparse.RawDescriptionHelpFormatter,
             usage=(
                 "managedtenants --addons-dir ADDONS_DIR [--addon-name"
-                " ADDON_NAME] [--dry-run] [--debug] bundles [-h] [--quay-org"
-                " QUAY_ORG] [--force-push] [--enable-gitlab]"
+                " ADDON_NAME] [--dry-run] [--debug]"
+                " bundles [-h] [--build-with {tag,digest}] [--quay-org QUAY_ORG"
+                "] [--force-push] [--enable-gitlab]"
             ),
         )
         bundles_parser.add_argument(
@@ -144,6 +146,15 @@ class Cli:
             action="store_true",
             default=False,
             help="Enforce the single-bundle-per-operator pattern.",
+        )
+        bundles_parser.add_argument(
+            "--build-with",
+            choices=["tag", "digest"],
+            default="digest",
+            help=(
+                "To specify the format that bundles use when"
+                " index image is built"
+            ),
         )
 
         self.args = parser.parse_args()


### PR DESCRIPTION
Signed-off-by: Priyanshu Raj <prraj@redhat.com>

# py-mtcli

## Description

fix for https://issues.redhat.com/browse/MTSRE-586

Next step:
- Add `--build-with tag` in the `check` target here: https://gitlab.cee.redhat.com/service/managed-tenants-bundles/-/blob/main/Makefile#L29-35