### PR TITLE
[MTSRE-592] fix: allowing anchor tags '#' in addon 'link' field

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: trailing-whitespace
   # Black
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
         args: ["--config", ".linters/black", "--experimental-string-processing"]

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -17,7 +17,7 @@ properties:
     description: "Short description for the addon."
   link:
     type: string
-    pattern: ^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$
+    pattern: ^http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&#+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+$
     description: "Link to the addon documentation."
   icon:
     type: string


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- Fixed 'link' validation regex to accept `#` anchor tags.