### PR TITLE
[MTSRE-594] validation for additionalCatalogSource Images

### DIFF
--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -71,7 +71,7 @@
 
     - **`name`** *(string)*: Name of the additional catalog source.
 
-    - **`image`** *(string)*: Url of the additional catalog source image.
+    - **`image`** *(string)*: Url of the additional catalog source image in digest format.
 
 - **`namespaceLabels`** *(object)*: Labels to be applied on all listed namespaces.
 

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -143,7 +143,8 @@ properties:
           description: "Name of the additional catalog source."
         image:
           type: string
-          description: "Url of the additional catalog source image."
+          pattern: ([\w\-]+[.][\w\-.]+([:][0-9]+)?\/)([\w\-]+\/)?[\w\-.]+(@sha256:[0-9a-f]{64})$
+          description: "Url of the additional catalog source image in digest format."
       required:
         - name
         - image

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -143,7 +143,7 @@ properties:
           description: "Name of the additional catalog source."
         image:
           type: string
-          pattern: ([\w\-]+[.][\w\-.]+([:][0-9]+)?\/)([\w\-]+\/)?[a-zA-Z0-9][\w\-.]+[a-zA-Z0-9](@sha256:[0-9a-f]{64})$
+          pattern: .*@sha256:[0-9a-f]{64}$
           description: "Url of the additional catalog source image in digest format."
       required:
         - name

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -143,7 +143,7 @@ properties:
           description: "Name of the additional catalog source."
         image:
           type: string
-          pattern: ([\w\-]+[.][\w\-.]+([:][0-9]+)?\/)([\w\-]+\/)?[\w\-.]+(@sha256:[0-9a-f]{64})$
+          pattern: ([\w\-]+[.][\w\-.]+([:][0-9]+)?\/)([\w\-]+\/)?[a-zA-Z0-9][\w\-.]+[a-zA-Z0-9](@sha256:[0-9a-f]{64})$
           description: "Url of the additional catalog source image in digest format."
       required:
         - name

--- a/tests/addons/test_addon.py
+++ b/tests/addons/test_addon.py
@@ -19,6 +19,7 @@ from tests.testutils.addon_helpers import (  # noqa: F401; noqa: F401; flake8: n
     addon_with_imageset_and_no_config,
     addon_with_imageset_path,
     addon_with_indeximage_path,
+    addon_with_invalid_additionalctlgsource_images_path,
     addon_with_only_imageset_config,
     addon_with_secrets_path,
     load_yaml,
@@ -97,6 +98,11 @@ def test_additional_catalogue_src_name_validation():
     metadata["additionalCatalogSources"].append(duplicate)
     with pytest.raises(AddonLoadError):
         addon._validate_additional_catalogue_srcs(metadata)
+
+
+def test_additional_catalogue_src_image_validation():
+    with pytest.raises(AddonLoadError):
+        Addon(addon_with_invalid_additionalctlgsource_images_path(), "stage")
 
 
 def test_secret_names_validation():

--- a/tests/testdata/addons/mock-operator-with-invalid-additionalctlgsource-images/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-invalid-additionalctlgsource-images/metadata/stage/addon.yaml
@@ -1,0 +1,33 @@
+---
+id: mockoperator-2
+name: Mock Operator
+description: This is a mock operator.
+icon: mock
+label: "api.openshift.com/addon-mock-operator-custom"
+enabled: true
+addonOwner: Mock <mock@redhat.com>
+quayRepo: quay.io/osd-addons/mock-operator-custom
+installMode: OwnNamespace
+targetNamespace: mock-operator
+indexImage: quay.io/osd-addons/mock-operator-custom-index
+namespaces:
+  - mock-operator
+namespaceLabels:
+  monitoring-key: mock
+namespaceAnnotations: {}
+ocmQuotaName: addon-mock-operator
+ocmQuotaCost: 1
+testHarness: quay.io/mock-operator/mock-operator-test-harness
+operatorName: mock-operator-two
+hasExternalResources: true
+channels:
+- name: alpha
+  currentCSV: mock-operator-custom-v1.0.0
+defaultChannel: alpha
+bundleParameters:
+  useClusterStorage: "true"
+additionalCatalogSources:
+  - name: new-catalog
+    image: quay.io/osd-addons/test-operator-custom-source:v4.10.1
+  - name: custom-catalog
+    image: quay.io/redhat-addons/redhat-operator-main:v4.10.3

--- a/tests/testdata/addons/mock-operator-with-secrets/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-secrets/metadata/stage/addon.yaml
@@ -44,4 +44,4 @@ secrets:
 pullSecretName: pull-secret-one
 additionalCatalogSources:
   - name: new-catalog
-    image: quay.io/osd-addons/test-operator-index@sha256:12ce3270c72134273440c477653b568980b407722366080af758b138f43861891
+    image: quay.io/osd-addons/test-operator-index@sha256:12ce3270c72134273440c477653b568980b407722366080af758b138f4386189

--- a/tests/testdata/addons/test-operator/metadata/integration/addon.yaml
+++ b/tests/testdata/addons/test-operator/metadata/integration/addon.yaml
@@ -19,7 +19,7 @@ defaultChannel: alpha
 namespaceLabels: {}
 additionalCatalogSources:
   - name: new-catalog
-    image: quay.io/osd-addons/test-operator-index@sha256:12ce3270c72134273440c477653b568980b407722366080af758b138f43861891
+    image: quay.io/osd-addons/test-operator-index@sha256:12ce3270c72134273440c477653b568980b407722366080af758b138f4386189
 namespaceAnnotations: {}
 indexImage: quay.io/osd-addons/test-operator-index@sha256:8980b407722366080af758b138f438618912ce3270c72134273440c477653b56
 pullSecret: test-pull-secret

--- a/tests/testutils/addon_helpers.py
+++ b/tests/testutils/addon_helpers.py
@@ -45,6 +45,12 @@ def addon_with_secrets_path():
     return Path("tests/testdata/addons/mock-operator-with-secrets")
 
 
+def addon_with_invalid_additionalctlgsource_images_path():
+    return Path(
+        "tests/testdata/addons/mock-operator-with-invalid-additionalctlgsource-images"
+    )
+
+
 def addon_with_duplicate_keys_path():
     return Path("tests/testdata/addons/mock-operator-with-duplicate-keys")
 


### PR DESCRIPTION
Signed-off-by: Priyanshu Raj <prraj@redhat.com>

# py-mtcli

## Description

Short description of the change:

Added validation check for additionalCatalogSource images to be present in digest format.
https://issues.redhat.com/browse/MTSRE-594