### PR TITLE
[MTSRE-469] bumped up operator_sdk version.

### DIFF
--- a/managedtenants/bundles/binary_deps.py
+++ b/managedtenants/bundles/binary_deps.py
@@ -22,4 +22,4 @@ class LazyBin:
 
 OPM = LazyBin(Opm, version="1.19.5", download_path="/tmp")
 MTCLI = LazyBin(Mtcli, version="0.10.0", download_path="/tmp")
-OPERATOR_SDK = LazyBin(OperatorSDK, version="1.4.2", download_path="/tmp")
+OPERATOR_SDK = LazyBin(OperatorSDK, version="1.18.0", download_path="/tmp")


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

# py-mtcli

## Description

Short description of the change:

- Bumped up `operator_sdk` version from `1.4.2` to `1.18.0`.

