### PR TITLE
[MTSRE-600] added upgradeStrategy for additionalCatalogSources

### DIFF
--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -101,6 +101,9 @@ items:
         secrets:
           - {{ADDON.pull_secret_name()}}
         {% endif %}
+        upgradeStrategy:
+          registryPoll:
+            interval: 10m
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Signed-off-by: Priyanshu Raj <prraj@redhat.com>

# py-mtcli

## Description

Short description of the change:

added `upgradeStrategy` for additionalCatalogSources.
https://issues.redhat.com/browse/MTSRE-600