### PR TITLE
Adding fields to control add-on option's editable direction

### DIFF
--- a/managedtenants/schemas/shared/addon_parameters.json
+++ b/managedtenants/schemas/shared/addon_parameters.json
@@ -50,6 +50,13 @@
       "editable": {
         "type": "boolean"
       },
+      "editable_direction": {
+        "type": "string",
+        "enum": [
+          "up",
+          "down"
+        ]
+      },
       "enabled": {
         "type": "boolean"
       },
@@ -74,6 +81,9 @@
             "value": {
               "type": "string",
               "format": "printable"
+            },
+            "rank": {
+              "type": "integer"
             },
             "requirements":{
               "$ref": "addon_requirements.json"


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- `managedtenants/schemas/shared/addon_parameters.json`
  Added `editable_direction` to parameter and `rank` to parameter options
