### PR TITLE
fix: fail early when addon paramter has disallowed property combinations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         args: ["--config", ".linters/flake8"]
   # Yamllint
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.3
+    rev: v1.27.1
     hooks:
       - id: yamllint
         args: ["--config-file", ".linters/yamllint"]

--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -135,7 +135,7 @@
 
 - **`indexImage`** *(string)*
 
-- **`addonImageSetVersion`** *(string)*: A string which specifies the imageset to use. Can either be 'latest' or a version string).
+- **`addonImageSetVersion`**: A string which specifies the imageset to use. Can either be 'latest' or a version string).
 
 - **`pagerduty`** *(object)*: Cannot contain additional properties.
 

--- a/managedtenants/schemas/shared/addon_parameters.json
+++ b/managedtenants/schemas/shared/addon_parameters.json
@@ -12,6 +12,18 @@
       "editable",
       "enabled"
     ],
+    "dependencies": {
+      "editable_direction": {
+        "properties": {
+          "options": {
+            "minItems": 1
+          }
+        },
+        "required": [
+          "options"
+        ]
+      }
+    },
     "properties": {
       "id": {
         "type": "string",
@@ -83,7 +95,8 @@
               "format": "printable"
             },
             "rank": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 0
             },
             "requirements":{
               "$ref": "addon_requirements.json"

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "Jinja2~=2.10",
         "markupsafe~=2.0.1",
         "PyYAML~=5.4.1",
-        "jsonschema~=3.1",
+        "jsonschema~=4.7",
         "requests~=2.23",
         "sretoolbox~=1.3.0",
         "semver~=2.13.0",

--- a/tests/testdata/addons/mock-operator-with-imagesets/addonimagesets/stage/mock-operator.v1.0.1.yml
+++ b/tests/testdata/addons/mock-operator-with-imagesets/addonimagesets/stage/mock-operator.v1.0.1.yml
@@ -13,7 +13,15 @@ addOnParameters:
     value_type: resource_requirement
     required: true
     editable: true
+    editable_direction: up
     enabled: true
+    options:
+      - name: 1 TiB
+        value: '1'
+        rank: 0
+      - name: 4 TiB
+        value: '4'
+        rank: 1
   - id: duration
     name: Managed StorageCluster duration
     description:


### PR DESCRIPTION
# py-mtcli

## Description

Adds the following validations for addon parameters:

- If `editable_direction` is defined, then `options` must be defined and non-empty
- For every `option` _o_, if _o.rank_ is defined, then _o.rank_ must be non-negative