### PR TITLE
fix: skip existing files in dist/ while making a release to avoid PyPI distribution conflcts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
   ###
   # Flake8
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.1
     hooks:
       - id: flake8
         args: ["--config", ".linters/flake8"]

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test:
 release:
 	python -m pip install twine wheel
 	python setup.py bdist_wheel
-	python -m twine upload dist/*
+	python -m twine upload --skip-existing dist/*
 
 generate: generate-md-schemas pre-commit-autoupdate
 


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

# py-mtcli

## Description

Short description of the change:

A bunch of repetitive errors have been happening on the build_tag task on Jenkins.
And the logs suggest that it's happening during twine tries to upload the package to PyPI. The errors seems to originate from uploading the same distributions of py-mtcli again on PyPI.

```sh
14:26:05 WARNING  Error during upload. Retry with the --verbose option for more details. 
14:26:05 ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
14:26:05          File already exists. See https://pypi.org/help/#file-name-reuse for    
14:26:05          more information.                                                      
14:26:05 make: *** [Makefile:68: release] Error 1
14:26:05 Build step 'Execute shell' marked build as failure
```

Fix was to just tell twine to ignore/skip the distributions which were already pushed to PyPI. And that's done in this PR via a `--skip-existing` flag to the twine command.

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
