### PR TITLE
Feat/ocm shortcircuit migrate

### DIFF
--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -35,7 +35,7 @@
 
 - **`installMode`** *(string)*: OLM InstallMode for the addon operator. Must be one of: `['AllNamespaces', 'OwnNamespace']`.
 
-- **`syncsetMigration`** *(string)*: The step currently in consideration in the process of migrating the addon to SyncSet. Must be one of: `['step 0 - delete addon migration', 'step 1 - block installations', 'step 2 - orphan SSS objects', 'step 3 - change SSS label', 'step 4 - enable syncset', 'step 5 - migration complete', 'rollback step 1 - ocm', 'rollback step 2 - selectorsyncset', 'rollback step 3 - reset addon migration']`.
+- **`syncsetMigration`** *(string)*: The step currently in consideration in the process of migrating the addon to SyncSet. Must be one of: `['shortcircuit whitelist', 'step 0 - delete addon migration', 'step 1 - block installations', 'step 2 - orphan SSS objects', 'step 3 - change SSS label', 'step 4 - enable syncset', 'step 5 - migration complete', 'rollback step 1 - ocm', 'rollback step 2 - selectorsyncset', 'rollback step 3 - reset addon migration']`.
 
 - **`manualInstallPlanApproval`** *(boolean)*
 

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -60,6 +60,7 @@ properties:
   syncsetMigration:
     type: string
     enum:
+      - "shortcircuit whitelist"
       - "step 0 - delete addon migration"
       - "step 1 - block installations"
       - "step 2 - orphan SSS objects"


### PR DESCRIPTION
# py-mtcli

## Description
Adds a new method called `shortcircuit_migrate` to the ocm client class which creates the migration object, enables it and then whitelists it, all wrapped in timeouts and max tries.
