### PR TITLE
Added shortcircuit whitelist in metadata.schema.yaml

### DIFF
--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -66,6 +66,7 @@ properties:
       - "step 3 - change SSS label"
       - "step 4 - enable syncset"
       - "step 5 - migration complete"
+      - "shortcircuit whitelist"
       - "rollback step 1 - ocm"
       - "rollback step 2 - selectorsyncset"
       - "rollback step 3 - reset addon migration"


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- Added `shortcircuit whitelist` in the syncsetMigration enum of `metadata.schema.yaml` present under `managedtenants/schemas`

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
