### PR TITLE
adding support for specifying taints and label requirements

### DIFF
--- a/managedtenants/schemas/shared/addon_requirements.json
+++ b/managedtenants/schemas/shared/addon_requirements.json
@@ -92,6 +92,33 @@
           },
           "replicas": {
             "type": "integer"
+          },
+          "taints": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "key": {
+                  "type": "string",
+                  "format": "printable"
+                },
+                "value": {
+                  "type": "string",
+                  "format": "printable"
+                },
+                "effect": {
+                  "type": "string",
+                  "format": "printable"
+                }
+              },
+              "format": "printable"
+            }
+          },
+          "labels": {
+            "type": "object",
+            "additionalProperties": true,
+            "format": "printable"
           }
         }
       },


### PR DESCRIPTION
# py-mtcli

## Description
Adding support for specifying taints and label requirements in accordance with [SDA-6531](https://issues.redhat.com/browse/SDA-6531)

Short description of the change:

Updated the schema for addon requirements

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
