### PR TITLE
remove channels parameter

### DIFF
--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -206,19 +206,6 @@ properties:
       addonParamsSecretName:
         type: string
         pattern: ^addon-[0-9A-Za-z-]+-parameters$
-  channels:
-    type: array
-    description: "DEPRECATED, can safely be removed."
-    items:
-      type: object
-      additionalProperties: false
-      properties:
-        name:
-          type: string
-          format: printable
-        currentCSV:
-          type: string
-          format: printable
   startingCSV:
     type: string
     format: printable

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -208,6 +208,7 @@ properties:
         pattern: ^addon-[0-9A-Za-z-]+-parameters$
   channels:
     type: array
+    description: "DEPRECATED, can safely be removed."
     items:
       type: object
       additionalProperties: false

--- a/tests/testdata/addons/mock-operator-with-duplicate-keys/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-duplicate-keys/metadata/stage/addon.yaml
@@ -22,9 +22,6 @@ targetNamespace: redhat-namespace
 testHarness: quay.io/mock-operator/mock-operator-test-harness
 operatorName: mock-operator
 hasExternalResources: true
-channels:
-- name: alpha
-  currentCSV: mock-operator-v1.0.0
 defaultChannel: alpha
 bundleParameters:
   useClusterStorage: "true"

--- a/tests/testdata/addons/mock-operator-with-imagesets/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-imagesets/metadata/stage/addon.yaml
@@ -19,9 +19,6 @@ ocmQuotaCost: 1
 testHarness: quay.io/mock-operator/mock-operator-test-harness
 operatorName: mock-operator
 hasExternalResources: true
-channels:
-- name: alpha
-  currentCSV: mock-operator-v1.0.0
 defaultChannel: alpha
 pullSecretName: pull-secret-one
 additionalCatalogSources:

--- a/tests/testdata/addons/mock-operator-with-only-required-attrs/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-only-required-attrs/metadata/stage/addon.yaml
@@ -19,8 +19,5 @@ ocmQuotaCost: 1
 testHarness: quay.io/mock-operator/mock-operator-test-harness
 operatorName: mock-operator
 hasExternalResources: true
-channels:
-- name: alpha
-  currentCSV: mock-operator-v1.0.0
 defaultChannel: alpha
 addonImageSetVersion: 1.0.0

--- a/tests/testdata/addons/mock-operator-with-secrets/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-secrets/metadata/stage/addon.yaml
@@ -20,9 +20,6 @@ ocmQuotaCost: 1
 testHarness: quay.io/mock-operator/mock-operator-test-harness
 operatorName: mock-operator-secrets
 hasExternalResources: true
-channels:
-- name: alpha
-  currentCSV: mock-operator-secrets-v1.0.0
 defaultChannel: alpha
 bundleParameters:
   useClusterStorage: "true"


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- deprecate channels parameter

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
