### PR TITLE
fix: ADDON_KEYS mapping to right ocm keys

### DIFF
--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -50,7 +50,7 @@ class OcmCli:
         "subOperators": "sub_operators",
         "managedService": "managed_service",
         "config": "config",
-        "namespaces": "namespaces",
+        "namespaces": "namespace",
     }
 
     IMAGESET_KEYS = {

--- a/tests/utils/test_ocm.py
+++ b/tests/utils/test_ocm.py
@@ -239,7 +239,7 @@ def test_ocm_addon_default_values(addon_str, expected_result, request):
         (
             "addon_without_imageset_and_only_required_attrs",
             {
-                "namespaces": [
+                "namespace": [
                     {
                         "name": "mock-operator",
                         "labels": {"monitoring-key": "mock"},
@@ -250,7 +250,7 @@ def test_ocm_addon_default_values(addon_str, expected_result, request):
         (
             "addon_with_deadmanssnitch",
             {
-                "namespaces": [
+                "namespace": [
                     {
                         "name": "redhat-test-operator",
                         "labels": {},


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

# py-mtcli

## Description

Changed `namespaces` to `namespace`.
API reference: https://api.openshift.com/#/default/post_api_clusters_mgmt_v1_addons
Ref:
1. 
```
"credentials_requests": [
    {
      "name": "string",
      "namespace": "string",
      "policy_permissions": [
        "string"
      ],
      "service_account": "string"
    }
  ]
```
2. Console output: 
```
{"kind":"Error","id":"400","href":"/api/clusters_mgmt/v1/errors/400","code":"CLUSTERS-MGMT-400","reason":"Bad request body: json: cannot unmarshal object into Go struct field AddOnNamespace.namespaces.name of type string","operation_id":"9bda96d7-02d1-4657-b894-949a72450e9a"}
```
