### PR TITLE
Apantuso/fix namespace propagation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: trailing-whitespace
   # Black
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
       - id: black
         args: ["--config", ".linters/black", "--experimental-string-processing"]
@@ -51,7 +51,7 @@ repos:
         args: ["--config", ".linters/flake8"]
   # Yamllint
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.27.1
+    rev: v1.28.0
     hooks:
       - id: yamllint
         args: ["--config-file", ".linters/yamllint"]

--- a/docs/tenants/zz_metadata_schema_generated.md
+++ b/docs/tenants/zz_metadata_schema_generated.md
@@ -107,14 +107,6 @@
 
   - **`addonParamsSecretName`** *(string)*
 
-- **`channels`** *(array)*
-
-  - **Items** *(object)*: Cannot contain additional properties.
-
-    - **`name`** *(string)*
-
-    - **`currentCSV`** *(string)*
-
 - **`startingCSV`** *(string)*
 
 - **`indexImage`** *(string)*

--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -50,7 +50,7 @@ class OcmCli:
         "subOperators": "sub_operators",
         "managedService": "managed_service",
         "config": "config",
-        "namespaces": "namespace",
+        "namespaces": "namespaces",
     }
 
     IMAGESET_KEYS = {

--- a/tests/utils/test_ocm.py
+++ b/tests/utils/test_ocm.py
@@ -239,7 +239,7 @@ def test_ocm_addon_default_values(addon_str, expected_result, request):
         (
             "addon_without_imageset_and_only_required_attrs",
             {
-                "namespace": [
+                "namespaces": [
                     {
                         "name": "mock-operator",
                         "labels": {"monitoring-key": "mock"},
@@ -250,7 +250,7 @@ def test_ocm_addon_default_values(addon_str, expected_result, request):
         (
             "addon_with_deadmanssnitch",
             {
-                "namespace": [
+                "namespaces": [
                     {
                         "name": "redhat-test-operator",
                         "labels": {},

--- a/tests/utils/test_ocm.py
+++ b/tests/utils/test_ocm.py
@@ -271,3 +271,29 @@ def test_ocm_addon_namespace_with_labels(addon_str, expected_result, request):
         ocm_addon = ocm_cli._addon_from_metadata(metadata=addon.metadata)
     for k, expected_value in expected_result.items():
         assert ocm_addon.get(k) == expected_value
+
+
+@pytest.mark.parametrize(
+    "addon_str,expected_result",
+    [
+        (
+            "addon_with_deadmanssnitch",
+            {
+                "namespaces": [
+                    {
+                        "name": "redhat-test-operator",
+                        "labels": {},
+                    }
+                ],
+            },
+        ),
+    ],
+)
+def test_ocm_addon_namespace_idempotent(addon_str, expected_result, request):
+    addon = request.getfixturevalue(addon_str)
+    ocm_cli = OcmCli(offline_token=None)
+    ocm_cli._addon_from_metadata(metadata=addon.metadata)
+    ocm_addon = ocm_cli._addon_from_metadata(metadata=addon.metadata)
+
+    for k, expected_value in expected_result.items():
+        assert ocm_addon.get(k) == expected_value


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- Reverts `namespaces` ocm field name change
- Maintains idempotentency for adddon data within upsert operations (add then update).

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
