### PR TITLE
[MTSRE-712] fix: index addon parameters starting from 1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: trailing-whitespace
   # Black
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
         args: ["--config", ".linters/black", "--experimental-string-processing"]

--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -488,7 +488,7 @@ class OcmCli:
         # so that they can be shown in the same order as
         # the metadata file.
         for index, param in enumerate(params):
-            param["order"] = index
+            param["order"] = index + 1
         return {"items": params}
 
     # Maps a secret from the addon metadata json to the one ocm expects.


### PR DESCRIPTION
### Summary

Clusters-service ignores `order` updates to addon parameters with `order=0` since `0` is a useful default in go. This starts all parameter lists at index `1` so that updates by tenants are actually reflected in OCM.