### PR TITLE
[MTSRE-515] feat: introduce monitoringStack API to the metadata

### DIFF
--- a/managedtenants/core/addons_loader/package.py
+++ b/managedtenants/core/addons_loader/package.py
@@ -21,11 +21,11 @@ class Package:
         return json.dumps(self.data, indent=4)
 
     def _get_data(self):
-        return dict(
-            packageName=self._addon.metadata["id"],
-            defaultChannel=self._addon.metadata["defaultChannel"],
-            channels=self._addon.metadata["channels"],
-        )
+        return {
+            "packageName": self._addon.metadata["id"],
+            "defaultChannel": self._addon.metadata["defaultChannel"],
+            "channels": self._addon.metadata["channels"],
+        }
 
     def __repr__(self):
         return f"{self.__class__.__name__}({repr(self._addon.name)})"

--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -163,7 +163,43 @@ items:
 {% endif %}
 
 {# federated metrics namespace + ServiceMonitor (v1 only) #}
-{% if ADDON.metadata['monitoring'] is defined %}
+{% if ADDON.metadata['metricsFederation'] is defined %}
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: redhat-monitoring-{{ ADDON.metadata['id'] }}
+        labels:
+          openshift.io/cluster-monitoring: 'true'
+    - apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        name: federated-sm-{{ ADDON.metadata['id'] }}
+        namespace: redhat-monitoring-{{ ADDON.metadata['id'] }}
+      spec:
+        endpoints:
+          - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honorLabels: true
+            port: {{ ADDON.metadata['metricsFederation']['portName'] }}
+            path: /federate
+            scheme: https
+            interval: 30s
+            tlsConfig:
+              caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+              serverName: prometheus.{{ ADDON.metadata['metricsFederation']['namespace'] }}.svc
+            params:
+              'match[]':
+                - ALERTS{alertstate="firing"}
+              {% for matchName in ADDON.metadata['metricsFederation']['matchNames'] %}
+                - '{__name__="{{ matchName }}"}'
+              {% endfor %}
+        namespaceSelector:
+          matchNames:
+            - {{ ADDON.metadata['metricsFederation']['namespace'] }}
+        selector:
+          matchLabels:
+            {{ expand_dict(ADDON.metadata['metricsFederation']['matchLabels']) | indent(12) }}
+{# Backwards-compatibility to the DEPRECATED 'monitoring' field #}
+{% elif ADDON.metadata['monitoring'] is defined %}
     - apiVersion: v1
       kind: Namespace
       metadata:

--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -130,6 +130,39 @@ properties:
     description: "Annotations to be applied to all objects created in the SelectorSyncSet."
   monitoring:
     type: object
+    description: "[DEPRECATED] Configuration parameters to be injected in the ServiceMonitor used for federation. The target prometheus server found by matchLabels needs to serve service-ca signed TLS traffic (https://docs.openshift.com/container-platform/4.6/security/certificate_types_descriptions/service-ca-certificates.html), and it needs to be runing inside the monitoring.namespace, with the service name 'prometheus'."
+    additionalProperties: false
+    required:
+      - portName
+      - namespace
+      - matchNames
+      - matchLabels
+    properties:
+      portName:
+        type: string
+        pattern: ^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$
+        description: "The name of the service port fronting the prometheus server."
+      namespace:
+        type: string
+        pattern: ^[A-Za-z0-9][A-Za-z0-9-]{0,60}[A-Za-z0-9]$
+        description: "Namespace where the prometheus server is running."
+      matchNames:
+        type: array
+        items:
+          type: string
+          format: printable
+          pattern: ^[a-zA-Z_:][a-zA-Z0-9_:]*$
+        description: "List of series names to federate from the prometheus server."
+      matchLabels:
+        type: object
+        items:
+          type: string
+          format: printable
+          pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+        description: "List of labels used to discover the prometheus server(s) to be federated."
+        minItems: 1
+  metricsFederation:
+    type: object
     description: "Configuration parameters to be injected in the ServiceMonitor used for federation. The target prometheus server found by matchLabels needs to serve service-ca signed TLS traffic (https://docs.openshift.com/container-platform/4.6/security/certificate_types_descriptions/service-ca-certificates.html), and it needs to be runing inside the monitoring.namespace, with the service name 'prometheus'."
     additionalProperties: false
     required:
@@ -161,6 +194,52 @@ properties:
           pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
         description: "List of labels used to discover the prometheus server(s) to be federated."
         minItems: 1
+  monitoringStack:
+    type: object
+    description: "Configuration parameters which will determine the underlying configuration of the MonitoringStack CR which will be created in runtime whenever the respective addon would be installed"
+    additionalProperties: false
+    required:
+      - exists
+    properties:
+      exists:
+        type: boolean
+        description: "This denotes whether the addon requires the MonitoringStack CR to be created in runtime or not. Validation fails if it is provided as 'false' and at the same time other parameters are specified"
+      resources:
+        type: object
+        description: "Represents the resource quotas (requests/limits) to be allocated to the Prometheus instances which will be spun up consequently by the respective MonitoringStack CR in runtime. If not provided, the default values would be used: '{requests: {cpu: '100m', memory: '256M'}, limits:{memory: '512M', cpu: '500m'}}'"
+        additionalProperties: false
+        anyOf:
+        - required:
+          - cpu
+        - required:
+          - memory
+        properties:
+          requests:
+            type: object
+            description: "Represents the cpu/memory resources which would be requested by the Prometheus instances spun up consequently by the MonitoringStack CR in runtime"
+            additionalProperties: false
+            required:
+            - cpu
+            - memory
+            properties:
+              cpu:
+                type: string
+                pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$" ## Ref: https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L147
+              memory:
+                type: string
+                pattern: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$" ## Ref: https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go#L147
+          limits:
+            type: object
+            description: "Represents the max. amount of cpu/memory resources which would be accessible by the Prometheus instances spun up consequently by the MonitoringStack CR in runtime"
+            additionalProperties: false
+            required:
+            - cpu
+            - memory
+            properties:
+              cpu:
+                type: string
+              memory:
+                type: string
   defaultChannel:
     type: string
     enum:

--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -97,7 +97,7 @@ class OcmCli:
         }
 
         method = requests.post
-        response = method(url, data=data)
+        response = method(url, data=data)  # pylint: disable=missing-timeout
         self._raise_for_status(response, reqs_method=method, url=url)
         self._token = response.json()["access_token"]
         self._last_token_issue = now

--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -97,7 +97,7 @@ class OcmCli:
         }
 
         method = requests.post
-        response = method(url, data=data)  # pylint: disable=missing-timeout
+        response = method(url, data=data)
         self._raise_for_status(response, reqs_method=method, url=url)
         self._token = response.json()["access_token"]
         self._last_token_issue = now

--- a/tests/sss/test_federated_metrics.py
+++ b/tests/sss/test_federated_metrics.py
@@ -8,6 +8,94 @@ import tests.testutils.strategies as custom_strategies
 from managedtenants.core.addon_manager import AddonManager
 from managedtenants.core.addons_loader.sss import Sss
 
+@given(data=hypothesis_strategies.data())
+def test_metrics_federation_v1(data):
+    env = data.draw(custom_strategies.environment())
+    addon = data.draw(custom_strategies.addon(env))
+    addon.metadata["metricsFederation"] = {
+        "portName": data.draw(custom_strategies.k8s_name()),
+        "namespace": data.draw(custom_strategies.namespace()),
+        "matchNames": data.draw(
+            hypothesis_strategies.lists(custom_strategies.k8s_name())
+        ),
+        "matchLabels": data.draw(custom_strategies.labels()),
+    }
+
+    # Rerender selectorsyncset.yaml.j2
+    addon.sss = Sss(addon=addon)
+    walker = addon.sss.walker()
+
+    expected_ns_name = f"redhat-monitoring-{addon.metadata['id']}"
+
+    # validate namespace
+    found = False
+    for ns, _ in walker["sss_deploy"]["spec"]["resources"]["Namespace"]:
+        if ns == expected_ns_name:
+            found = True
+            break
+    assert found
+
+    # validate servicemonitor
+    _, sm = walker["sss_deploy"]["spec"]["resources"]["ServiceMonitor"][0]
+    assert sm["metadata"]["namespace"] == expected_ns_name
+
+    # validate endpoint.0
+    endpoint = sm["spec"]["endpoints"][0]
+    assert endpoint["port"] == addon.metadata["metricsFederation"]["portName"]
+    assert (
+        endpoint["bearerTokenFile"]
+        == "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    )
+
+    for matchName in addon.metadata["metricsFederation"]["matchNames"]:
+        series_name = f"""{{__name__="{matchName}"}}"""
+        assert series_name in endpoint["params"]["match[]"]
+
+    # validate selectors
+    assert (
+        addon.metadata["metricsFederation"]["namespace"]
+        == sm["spec"]["namespaceSelector"]["matchNames"][0]
+    )
+
+    for k, v in addon.metadata["metricsFederation"]["matchLabels"].items():
+        assert sm["spec"]["selector"]["matchLabels"][k] == v
+
+
+# For v2, the namespace and ServiceMonitor should be created and managed
+# by the addon-operator.
+@given(data=hypothesis_strategies.data())
+def test_metrics_federation_v2(data):
+    env = data.draw(custom_strategies.environment())
+    addon = data.draw(custom_strategies.addon(env))
+    addon.metadata["metricsFederation"] = {
+        "matchNames": data.draw(
+            hypothesis_strategies.lists(custom_strategies.k8s_name())
+        ),
+        "matchLabels": data.draw(custom_strategies.labels()),
+    }
+    addon.manager = AddonManager.ADDON_OPERATOR
+    addon.metadata["indexImage"] = custom_strategies.quay_image(
+        addon.metadata["id"]
+    )
+
+    # Rerender selectorsyncset.yaml.j2
+    addon.sss = Sss(addon=addon)
+    walker = addon.sss.walker()
+
+    expected_ns_name = f"redhat-monitoring-{addon.metadata['id']}"
+
+    # validate namespace does not exist
+    found = False
+    for ns, _ in walker["sss_deploy"]["spec"]["resources"]["Namespace"]:
+        if ns == expected_ns_name:
+            found = True
+            break
+    assert not found
+
+    # validate servicemonitor does not exist
+    with pytest.raises(IndexError):
+        _ = walker["sss_deploy"]["spec"]["resources"]["ServiceMonitor"][0]
+
 
 @given(data=hypothesis_strategies.data())
 def test_namespace_and_servicemonitor_v1(data):


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

# py-mtcli

## Description

introduces the support for the `monitoringStack` field in the metadata schema for specifying the config for the monitoring stack CR to be utilised by the addon-operator in runtime. 

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
