### PR TITLE
[MTSRE-796] Bump up OPM version to 1.24.0

### DIFF
--- a/managedtenants/bundles/binary_deps.py
+++ b/managedtenants/bundles/binary_deps.py
@@ -20,6 +20,6 @@ class LazyBin:
         self.instance.run(*cmd)
 
 
-OPM = LazyBin(Opm, version="1.19.5", download_path="/tmp")
+OPM = LazyBin(Opm, version="1.24.0", download_path="/tmp")
 MTCLI = LazyBin(Mtcli, version="0.10.0", download_path="/tmp")
 OPERATOR_SDK = LazyBin(OperatorSDK, version="1.4.2", download_path="/tmp")


### PR DESCRIPTION
Signed-off-by: Ankit Kurmi <akurmi@redhat.com>

# py-mtcli

## Description
Bumping OPM version from `1.19.5` to `1.24.0`.