### PR TITLE
Remove adding array indices as ids for additionalCatalogSources

### DIFF
--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -376,7 +376,7 @@ class OcmCli:
     def _set_default_values_for_addon_version(self, addon, metadata):
         # Set additionalCatalogSources
         mapped_key = self.IMAGESET_KEYS["additionalCatalogSources"]
-        addon[mapped_key] = self.index_dicts(metadata.get("additionalCatalogSources", []))
+        addon[mapped_key] = metadata.get("additionalCatalogSources", [])
 
         # Set default values for attributes under config in metadata,
         # if not present.
@@ -429,10 +429,6 @@ class OcmCli:
         for key, val in imageset.items():
             if key in self.IMAGESET_KEYS:
                 mapped_key = self.IMAGESET_KEYS[key]
-                if key == "additionalCatalogSources":
-                    catalog_src_list = self.index_dicts(val)
-                    addon[mapped_key] = catalog_src_list
-                    continue
                 if key == "config":
                     addon = self.set_addon_config(
                         addon=addon,


### PR DESCRIPTION
Remove call to `index_dict` in 2 occasions

- ie, treat `additionalCatalogSources` as a normal value eg: `addon[mapped_key] = val` (ref: https://github.com/mt-sre/managed-tenants-cli/blob/main/managedtenants/utils/ocm.py#L446)

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>

# py-mtcli

## Description

Short description of the change:

- modified X
- modified Y
- modified Z

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
