### PR TITLE
feat: update ocm-client

### DIFF
--- a/managedtenants/utils/ocm.py
+++ b/managedtenants/utils/ocm.py
@@ -59,6 +59,8 @@ class OcmCli:
         "managedService": "managed_service",
         "config": "config",
         "namespaces": "namespaces",
+        "commonAnnotations": "common_annotations",
+        "commonLabels": "common_labels"
     }
 
     IMAGESET_KEYS = {

--- a/tests/testdata/addons/mock-operator-with-imagesets/metadata/stage/addon.yaml
+++ b/tests/testdata/addons/mock-operator-with-imagesets/metadata/stage/addon.yaml
@@ -13,6 +13,12 @@ namespaces:
   - mock-operator
 namespaceLabels:
   monitoring-key: mock
+commonLabels:
+  cached:  addons.openshift.com/addon-operator
+  labels: present
+commonAnnotations:
+  cached:  addons.openshift.com/addon-operator
+  annotations: present
 namespaceAnnotations: {}
 ocmQuotaName: addon-mock-operator
 ocmQuotaCost: 1

--- a/tests/utils/test_ocm.py
+++ b/tests/utils/test_ocm.py
@@ -297,3 +297,36 @@ def test_ocm_addon_namespace_idempotent(addon_str, expected_result, request):
 
     for k, expected_value in expected_result.items():
         assert ocm_addon.get(k) == expected_value
+
+
+@pytest.mark.parametrize(
+    "addon_str,expected_result",
+    [
+        (
+            "addon_with_imageset_and_default_config",
+            {
+                "common_labels": {
+                    "cached":  "addons.openshift.com/addon-operator",
+                    "labels": "present"
+                },
+                "common_annotations":{
+                    "cached":  "addons.openshift.com/addon-operator",
+                    "annotations": "present"
+                }
+            }
+        ),
+        (
+            "addon_with_imageset_and_only_required_attrs",
+            {
+                "common_labels": None,
+                "common_annotations": None,
+            },
+        )
+    ]
+)
+def test_ocm_common_labels_and_annotations(addon_str, expected_result, request):
+    addon = request.getfixturevalue(addon_str)
+    ocm_cli = OcmCli(offline_token="dummy_value")
+    ocm_addon = ocm_cli._addon_from_metadata(metadata=addon.metadata)
+    for key, expected_value in expected_result.items():
+        assert ocm_addon.get(key) == expected_value


### PR DESCRIPTION
Include common_labels and common_annotations attribute in the json addon payload to OCM.

Signed-off-by: Ashish <asnaraya@redhat.com>


