### PR TITLE
fix: allow machine pool resources to have 'id' field under them as a part of requirements config

### DIFF
--- a/managedtenants/schemas/shared/addon_requirements.json
+++ b/managedtenants/schemas/shared/addon_requirements.json
@@ -103,6 +103,10 @@
                 },
                 "replicas": {
                   "type": "integer"
+                },
+                "id": {
+                  "type": "string",
+                  "format": "printable"
                 }
               }
             }


### PR DESCRIPTION

Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

# py-mtcli

## Description

the 'id' field in under the machine pool config is meant to be used by OCM managed-service to take decisions around the scaling or creation of existent or non-existent machine pool respectively.
