### PR TITLE
feat: feed metrics_federation / monitoring_stack config to OCM API calls of CS and AS accordingly

### DIFF
--- a/managedtenants/core/addons_loader/package.py
+++ b/managedtenants/core/addons_loader/package.py
@@ -21,11 +21,11 @@ class Package:
         return json.dumps(self.data, indent=4)
 
     def _get_data(self):
-        return dict(
-            packageName=self._addon.metadata["id"],
-            defaultChannel=self._addon.metadata["defaultChannel"],
-            channels=self._addon.metadata["channels"],
-        )
+        return {
+            "packageName": self._addon.metadata["id"],
+            "defaultChannel": self._addon.metadata["defaultChannel"],
+            "channels": self._addon.metadata["channels"],
+        }
 
     def __repr__(self):
         return f"{self.__class__.__name__}({repr(self._addon.name)})"


### PR DESCRIPTION
# py-mtcli

## Description

CS and AS are supposed to receive the `metricsFederation` config and `monitoring_stack` config respectively as well since SyncSets came into the picture. Due to the absence of this, no tenant in the fleet was able to provision resources oriented with metricsFederation since they were migrated to SyncSets.

This PR achieves that.

Note: this PR takes care of the fact that the addons-service and cluster-service aren't deployed to support for the `metrics_federation` and `monitoring_stack` fields. 
Hence, the `UNSUPPORTED_FIELDS_AS` and `UNSUPPORTED_FIELDS_CS` are involved in the PR.

In the future, once things are well-deployed and updated on CS's and AS's sides, all we need to do is to just update the values of `UNSUPPORTED_FIELDS_AS` and `UNSUPPORTED_FIELDS_CS` variables.
