### PR TITLE
chore: add order to addon parameters schemas

### DIFF
--- a/managedtenants/schemas/shared/addon_parameters.json
+++ b/managedtenants/schemas/shared/addon_parameters.json
@@ -101,6 +101,9 @@
         "type": "string",
         "format": "printable"
       },
+      "order": {
+        "type": "integer"
+      },
       "options": {
         "type": "array",
         "items": {


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- modified managedtenants/schemas/shared/addon_parameters.json, added order to parameter schema

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
