### PR TITLE
fix: update regex pattern to allow hyphen(-)

### DIFF
--- a/managedtenants/schemas/metadata.schema.yaml
+++ b/managedtenants/schemas/metadata.schema.yaml
@@ -158,7 +158,7 @@ properties:
         items:
           type: string
           format: printable
-          pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+          pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
         description: "List of labels used to discover the prometheus server(s) to be federated."
         minItems: 1
   metricsFederation:
@@ -191,7 +191,7 @@ properties:
         items:
           type: string
           format: printable
-          pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+          pattern: ^[a-zA-Z][a-zA-Z0-9_-]*$
         description: "List of labels used to discover the prometheus server(s) to be federated."
         minItems: 1
   monitoringStack:


### PR DESCRIPTION
## Description

Allow regex pattern to accept hyphen for `matchLabels` field in `monitoring/metricsFederation`.