### PR TITLE
use cluster scope when validating package

### DIFF
--- a/managedtenants/bundles/package_builder.py
+++ b/managedtenants/bundles/package_builder.py
@@ -46,6 +46,7 @@ class PackageBuilder:
 
         command = [
             "tree",
+            "--cluster",
             f"{addon_package.path.resolve()}",
         ]
         self.log.info(f'Validating package image "{package_image.url_tag}"')


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- modified X
- modified Y
- modified Z

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
