### PR TITLE
Update kubectl-package to v1.6.4

### DIFF
--- a/managedtenants/bundles/package_builder.py
+++ b/managedtenants/bundles/package_builder.py
@@ -25,7 +25,7 @@ class PackageBuilder:
         self.docker_api = docker_api
         self.build_with = build_with
         self.kubectl_package = KubectlPackage(
-            version="1.4.0", download_path="/tmp"
+            version="1.6.4", download_path="/tmp"
         )
         self.log = get_text_logger(
             "managedtenants-package-builder",


### PR DESCRIPTION
# py-mtcli

## Description

Updated kubectl package to latest Package Operator v1.6.3

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
