### PR TITLE
[MTSRE-1734] fix: bump index image base

### DIFF
--- a/managedtenants/bundles/index_builder.py
+++ b/managedtenants/bundles/index_builder.py
@@ -67,7 +67,7 @@ class IndexBuilder:
             "--binary-image",
             # Custom base image based on UBI, OPM 1.24.0
             # https://github.com/mt-sre/containers/tree/main/opm-ubi
-            "quay.io/mtsre/opm-ubi@sha256:4f1d7cc3d3399caaaba4716574fcbac74f5d213cc8d45a4bada0987263e74470",  # noqa: 501
+            "quay.io/mtsre/opm-ubi@sha256:b874c8814225383cea1c617245d84c95bf3b94622cac8373d2e791c1fcb679c4",  # noqa: 501
             "--permissive",
             "--bundles",
             ",".join(


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- modified X
- modified Y
- modified Z

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
