### PR TITLE
feat: PDI template changes for PDO service orchestration

### DIFF
--- a/managedtenants/data/selectorsyncset.yaml.j2
+++ b/managedtenants/data/selectorsyncset.yaml.j2
@@ -305,6 +305,11 @@ items:
     pagerdutyApiKeySecretRef:
       name: pagerduty-api-key
       namespace: pagerduty-operator
+    serviceOrchestration:
+      enabled: "true"
+      ruleConfigConfigMapRef:
+        name: osd-serviceorchestration
+        namespace: pagerduty-operator
     clusterDeploymentSelector:
       matchLabels:
           {{ADDON.metadata['label']}}: "true"


### PR DESCRIPTION
# py-mtcli
[MTSRE-1698](https://issues.redhat.com/browse/MTSRE-1698)
## Description

Short description of the change:

- modified X
- modified Y
- modified Z

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
