### PR TITLE
[MTSRE-1846] Upgrading operator-sdk version to 1.21.0

### DIFF
--- a/managedtenants/bundles/binary_deps.py
+++ b/managedtenants/bundles/binary_deps.py
@@ -22,4 +22,4 @@ class LazyBin:
 
 OPM = LazyBin(Opm, version="1.24.0", download_path="/tmp")
 MTCLI = LazyBin(Mtcli, version="0.10.0", download_path="/tmp")
-OPERATOR_SDK = LazyBin(OperatorSDK, version="1.4.2", download_path="/tmp")
+OPERATOR_SDK = LazyBin(OperatorSDK, version="1.21.0", download_path="/tmp")


### PR DESCRIPTION
# py-mtcli

## Description
Jira: [MTSRE-1846](https://issues.redhat.com/browse/MTSRE-1846)

Short description of the change:

- bumping `operator-sdk` version to `1.21.0`

## Checklist

**For any modification to `managedtenants/bundles/`**

- [ ] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
