### PR TITLE
[MTSRE-1907] Isolating methods for AS upsert

### DIFF
--- a/managedtenants/core/addons_loader/addon.py
+++ b/managedtenants/core/addons_loader/addon.py
@@ -250,14 +250,18 @@ class Addon:
                 f" {self.imagesets_path}"
             )
 
+        valid_imagesets = self.load_imagesets()
+        imageset = self.get_target_imageset(imagesets_iter=valid_imagesets)
+        self._validate_schema_instance(imageset, "imageset")
+        return imageset
+
+    def load_imagesets(self):
         def is_not_none(arg):
             return arg is not None
 
         imageset_yamls = map(self.load_yaml, self.get_available_imagesets())
         valid_imagesets = filter(is_not_none, imageset_yamls)
-        imageset = self.get_target_imageset(imagesets_iter=valid_imagesets)
-        self._validate_schema_instance(imageset, "imageset")
-        return imageset
+        return valid_imagesets
 
     def get_available_imagesets(self):
         imageset_files = (


### PR DESCRIPTION
# py-mtcli

## Description
Isolating in-house functions to make use in AS prod upsert.

Short description of the change:

- created `load_imagesets` to perform retrieval of all the valid imageset.

## Checklist

**For any modification to `managedtenants/bundles/`**

- [x] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
