### PR TITLE
Updating binaries used for building addons bundles

### DIFF
--- a/managedtenants/bundles/binary_deps.py
+++ b/managedtenants/bundles/binary_deps.py
@@ -20,6 +20,6 @@ class LazyBin:
         self.instance.run(*cmd)
 
 
-OPM = LazyBin(Opm, version="1.24.0", download_path="/tmp")
-MTCLI = LazyBin(Mtcli, version="0.10.0", download_path="/tmp")
-OPERATOR_SDK = LazyBin(OperatorSDK, version="1.21.0", download_path="/tmp")
+OPM = LazyBin(Opm, version="1.45.0", download_path="/tmp")
+MTCLI = LazyBin(Mtcli, version="0.20.1", download_path="/tmp")
+OPERATOR_SDK = LazyBin(OperatorSDK, version="1.36.0", download_path="/tmp")

--- a/managedtenants/bundles/package_builder.py
+++ b/managedtenants/bundles/package_builder.py
@@ -25,7 +25,7 @@ class PackageBuilder:
         self.docker_api = docker_api
         self.build_with = build_with
         self.kubectl_package = KubectlPackage(
-            version="1.9.0", download_path="/tmp"
+            version="1.12.0", download_path="/tmp"
         )
         self.log = get_text_logger(
             "managedtenants-package-builder",


### PR DESCRIPTION
# py-mtcli

## Description

Short description of the change:

- updated OPM version to v1.45.0
- updated MT-CLI (AMO) version v0.20.1
- updated Operator-SDK version to v1.36.0
- updated PKO version to v1.12.0

## Checklist

**For any modification to `managedtenants/bundles/`**

- [x] `$ managedtenants --addons-dir=../managed-tenants-bundles/addons --dry-run bundles` (successfuly built all addons)
- [ ] `$ managedtenants -addons-dir=../managed-tenants-bundles/addons --addon-name=<addon> bundles --quay-org <personal_org>` (successfuly built and push a single addon)
